### PR TITLE
Set FORGE_PHP_VERSION to use null to use default version

### DIFF
--- a/config/forge.php
+++ b/config/forge.php
@@ -35,7 +35,7 @@ return [
     'env_keys' => env('FORGE_ENV_KEYS'),
 
     // PHP version (default: 'php82').
-    'php_version' => env('FORGE_PHP_VERSION', 'php82'),
+    'php_version' => env('FORGE_PHP_VERSION'),
 
     // Type of the project (default: 'php').
     'project_type' => env('FORGE_PROJECT_TYPE', 'php'),


### PR DESCRIPTION
Based on issue #64 - I have made the **FORGE_PHP_VERSION** harbor config default value to null to use the Forge's default version - ensuring there is no break if the selected version is not installed on Forge 