### PR TITLE
Allow environment URL to be overridden by a local environment variable

### DIFF
--- a/app/Commands/ProvisionCommand.php
+++ b/app/Commands/ProvisionCommand.php
@@ -61,7 +61,7 @@ class ProvisionCommand extends Command
             ])
             ->then(function () use ($service) {
                 $this->success('Provisioning complete! Your environment is now set up and ready to use.');
-                $this->success('Site Link: '. $service->getSiteLink());
+                $this->success('Site Link: '.$service->getSiteLink());
             });
     }
 }

--- a/app/Services/Comments/EnvironmentUrlBuilder.php
+++ b/app/Services/Comments/EnvironmentUrlBuilder.php
@@ -37,6 +37,6 @@ class EnvironmentUrlBuilder implements CommentInterface
 
     public function getContent(): string
     {
-        return env('HARBOR_ENVIRONMENT_URL', $this->url);
+        return $this->url;
     }
 }

--- a/app/Services/Comments/EnvironmentUrlBuilder.php
+++ b/app/Services/Comments/EnvironmentUrlBuilder.php
@@ -37,6 +37,6 @@ class EnvironmentUrlBuilder implements CommentInterface
 
     public function getContent(): string
     {
-        return $this->url;
+        return env('HARBOR_ENVIRONMENT_URL', $this->url);
     }
 }

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -126,7 +126,7 @@ class ForgeService
 
     public function getSiteLink(): string
     {
-        if ( $this->setting->environmentUrl ){
+        if ($this->setting->environmentUrl) {
             return $this->setting->environmentUrl;
         }
 

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -126,8 +126,8 @@ class ForgeService
 
     public function getSiteLink(): string
     {
-        if ( env('HARBOR_ENVIRONMENT_URL') ) {
-            return env('HARBOR_ENVIRONMENT_URL');
+        if ( $this->setting->environmentUrl ){
+            return $this->setting->environmentUrl;
         }
 
         return ($this->site->isSecured ? 'https://' : 'http://').$this->site->name;

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -126,8 +126,8 @@ class ForgeService
 
     public function getSiteLink(): string
     {
-        if ( env('HARBOUR_ENVIRONMENT_URL') ) {
-            return env('HARBOUR_ENVIRONMENT_URL');
+        if ( env('HARBOR_ENVIRONMENT_URL') ) {
+            return env('HARBOR_ENVIRONMENT_URL');
         }
 
         return ($this->site->isSecured ? 'https://' : 'http://').$this->site->name;

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -126,6 +126,10 @@ class ForgeService
 
     public function getSiteLink(): string
     {
+        if ( env('HARBOUR_ENVIRONMENT_URL') ) {
+            return env('HARBOUR_ENVIRONMENT_URL');
+        }
+
         return ($this->site->isSecured ? 'https://' : 'http://').$this->site->name;
     }
 }

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -158,6 +158,11 @@ class ForgeSetting
     public ?string $subdomainName;
 
     /**
+     * Gets used to set the site subdomain manually.
+     */
+    public ?string $environmentUrl;
+
+    /**
      * The validation rules.
      */
     private array $validationRules = [
@@ -185,6 +190,7 @@ class ForgeSetting
         'git_issue_number' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'git_token' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'subdomain_name' => ['nullable', 'string', 'regex:/^[a-zA-Z0-9-_]+$/'],
+        'environment_url' => ['nullable', 'url'],
     ];
 
     public function __construct()

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -158,7 +158,7 @@ class ForgeSetting
     public ?string $subdomainName;
 
     /**
-     * Gets used to set the site subdomain manually.
+     * Gets used to set the site domain manually.
      */
     public ?string $environmentUrl;
 

--- a/config/forge.php
+++ b/config/forge.php
@@ -80,5 +80,5 @@ return [
     'subdomain_name' => env('SUBDOMAIN_NAME'),
 
     // Environment URL used for the provision site information comment.
-    'environment_url' => env('HARBOR_ENVIRONMENT_URL'),
+    'environment_url' => env('FORGE_ENVIRONMENT_URL'),
 ];

--- a/config/forge.php
+++ b/config/forge.php
@@ -78,4 +78,7 @@ return [
 
     // Subdomain name used for the Forge site domain instead of branch name.
     'subdomain_name' => env('SUBDOMAIN_NAME'),
+
+    // Environment URL used for the provision site information comment.
+    'environment_url' => env('HARBOR_ENVIRONMENT_URL'),
 ];


### PR DESCRIPTION
# Feature Improvement

Allows the environment URL that is published as part of the GitHub comment to be overridden with a local environment variable.

# Use Case 

In my app, I want to sent the QA team to a subdomain of the environment.  Going to the bare domain the site is launched on actually doesn't return the app (by design).  With this fix, I could put the URL, including subdomain, into the GitHub comment. 

# Implementation 

Adds a FORGE_ENVIRONMENT_URL environment variable that overrides the environment URL for the forge site. 