### PR TITLE
Send Slack Notification on Deployment

### DIFF
--- a/app/Commands/ProvisionCommand.php
+++ b/app/Commands/ProvisionCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace App\Commands;
 
 use App\Services\Forge\ForgeService;
+use App\Services\Forge\Pipeline\AnnounceSiteOnSlack;
 use App\Services\Forge\Pipeline\CreateDatabase;
 use App\Services\Forge\Pipeline\DeploySite;
 use App\Services\Forge\Pipeline\EnableQuickDeploy;
@@ -58,6 +59,7 @@ class ProvisionCommand extends Command
                 RunOptionalCommands::class,
                 EnsureJobScheduled::class,
                 PutCommentOnPullRequest::class,
+                AnnounceSiteOnSlack::class,
             ])
             ->then(function () use ($service) {
                 $this->success('Provisioning complete! Your environment is now set up and ready to use.');

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -28,7 +28,7 @@ class SiteProvisionedNotification extends Notification
             ->sectionBlock(function (SectionBlock $block) {
                 $block->text('An preview site has been deployed with Laravel Harbor');
 
-                $block->field("*Branch Name:*\nhttps://{$this->service->setting->gitProvider}.com/{$this->service->setting->repository}/tree/{$this->service->setting->branch}")->markdown();
+                $block->field("*Branch Name:*\n{$this->service->setting->branch}")->markdown();
                 $block->field("*Environment URL:*\n{$this->service->getSiteLink()}")->markdown();
             })
             ->dividerBlock()

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -23,6 +23,7 @@ class SiteProvisionedNotification extends Notification
     public function toSlack(object $notifiable): SlackMessage
     {
         return (new SlackMessage)
+            ->to($this->service->setting->slackChannel)
             ->text('A new site has been provisioned!')
             ->sectionBlock(function (SectionBlock $block) {
                 $block->text('An invoice has been paid.');

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -28,7 +28,7 @@ class SiteProvisionedNotification extends Notification
             ->sectionBlock(function (SectionBlock $block) {
                 $block->text('An preview site has been deployed with Laravel Harbor');
 
-                $block->field("*Branch Name URL:*\n{$this->service->setting->branch}")->markdown();
+                $block->field("*Branch Name:*\nhttps://{$this->service->setting->gitProvider}.com/{$this->service->setting->repository}{$this->service->setting->branch}")->markdown();
                 $block->field("*Environment URL:*\n{$this->service->getSiteLink()}")->markdown();
             })
             ->dividerBlock()

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Services\Forge\ForgeService;
 use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
+use Illuminate\Notifications\Slack\SlackChannel;
 use Illuminate\Notifications\Slack\SlackMessage;
 use Illuminate\Notifications\Notification;
 
@@ -16,7 +17,7 @@ class SiteProvisionedNotification extends Notification
 
     public function via(object $notifiable): array
     {
-        return ['slack'];
+        return [SlackChannel::class];
     }
 
     public function toSlack(object $notifiable): SlackMessage

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Services\Forge\ForgeService;
+use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
+use Illuminate\Notifications\Slack\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class SiteProvisionedNotification extends Notification
+{
+    public function __construct(protected ForgeService $service)
+    {
+        //
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['slack'];
+    }
+
+    public function toSlack(object $notifiable): SlackMessage
+    {
+        return (new SlackMessage)
+            ->text('A new site has been provisioned!')
+            ->sectionBlock(function (SectionBlock $block) {
+                $block->text('An invoice has been paid.');
+
+                $block->field("*Branch Name URL:*\n{$this->service->setting->branch}")->markdown();
+                $block->field("*Environment URL:*\n{$this->service->getSiteLink()}")->markdown();
+            })
+            ->dividerBlock()
+            ->sectionBlock(function (SectionBlock $block) {
+                $block->text('Congratulations!');
+            });
+    }
+}

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -26,7 +26,7 @@ class SiteProvisionedNotification extends Notification
             ->to($this->service->setting->slackChannel)
             ->text('A new site has been provisioned!')
             ->sectionBlock(function (SectionBlock $block) {
-                $block->text('An invoice has been paid.');
+                $block->text('An preview site has been deployed with Laravel Harbor');
 
                 $block->field("*Branch Name URL:*\n{$this->service->setting->branch}")->markdown();
                 $block->field("*Environment URL:*\n{$this->service->getSiteLink()}")->markdown();

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -1,12 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Harbor.
+ *
+ * (c) Mehran Rasulian <mehran.rasulian@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
 namespace App\Notifications;
 
 use App\Services\Forge\ForgeService;
+use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
 use Illuminate\Notifications\Slack\SlackChannel;
 use Illuminate\Notifications\Slack\SlackMessage;
-use Illuminate\Notifications\Notification;
 
 class SiteProvisionedNotification extends Notification
 {

--- a/app/Notifications/SiteProvisionedNotification.php
+++ b/app/Notifications/SiteProvisionedNotification.php
@@ -28,7 +28,7 @@ class SiteProvisionedNotification extends Notification
             ->sectionBlock(function (SectionBlock $block) {
                 $block->text('An preview site has been deployed with Laravel Harbor');
 
-                $block->field("*Branch Name:*\nhttps://{$this->service->setting->gitProvider}.com/{$this->service->setting->repository}{$this->service->setting->branch}")->markdown();
+                $block->field("*Branch Name:*\nhttps://{$this->service->setting->gitProvider}.com/{$this->service->setting->repository}/tree/{$this->service->setting->branch}")->markdown();
                 $block->field("*Environment URL:*\n{$this->service->getSiteLink()}")->markdown();
             })
             ->dividerBlock()

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -165,7 +165,7 @@ class ForgeSetting
     /**
      * The OAuth Token for the Slack Bot
      */
-    public ?string $slackBotToken;
+    public ?string $slackBotUserOauthToken;
 
     /**
      * Which channel to announce to on Slack
@@ -201,7 +201,7 @@ class ForgeSetting
         'git_token' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'subdomain_name' => ['nullable', 'string', 'regex:/^[a-zA-Z0-9-_]+$/'],
         'slack_announcement_enabled' => ['required', 'boolean'],
-        'slack_bot_token' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],
+        'slack_bot_user_oauth_token' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],
         'slack_channel' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],
     ];
 

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -158,6 +158,11 @@ class ForgeSetting
     public ?string $subdomainName;
 
     /**
+     * Is the Slack integration enabled?
+     */
+    public bool $slackAnnouncementEnabled;
+
+    /**
      * The OAuth Token for the Slack Bot
      */
     public ?string $slackBotToken;
@@ -195,8 +200,9 @@ class ForgeSetting
         'git_issue_number' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'git_token' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'subdomain_name' => ['nullable', 'string', 'regex:/^[a-zA-Z0-9-_]+$/'],
-        'slack_bot_token' => ['nullable', 'string'],
-        'slack_channel' => ['nullable', 'string'],
+        'slack_announcement_enabled' => ['required', 'boolean'],
+        'slack_bot_token' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],
+        'slack_channel' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],
     ];
 
     public function __construct()

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -158,9 +158,14 @@ class ForgeSetting
     public ?string $subdomainName;
 
     /**
-     * Gets used to set the site subdomain manually.
+     * The OAuth Token for the Slack Bot
      */
-    public ?string $slackWebhookUrl;
+    public ?string $slackBotToken;
+
+    /**
+     * Which channel to announce to on Slack
+     */
+    public ?string $slackChannel;
 
     /**
      * The validation rules.
@@ -190,7 +195,8 @@ class ForgeSetting
         'git_issue_number' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'git_token' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'subdomain_name' => ['nullable', 'string', 'regex:/^[a-zA-Z0-9-_]+$/'],
-        'slack_webhook_url' => ['nullable', 'url'],
+        'slack_bot_token' => ['nullable', 'string'],
+        'slack_channel' => ['nullable', 'string'],
     ];
 
     public function __construct()

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -158,6 +158,11 @@ class ForgeSetting
     public ?string $subdomainName;
 
     /**
+     * Gets used to set the site subdomain manually.
+     */
+    public ?string $slackWebhookUrl;
+
+    /**
      * The validation rules.
      */
     private array $validationRules = [
@@ -185,6 +190,7 @@ class ForgeSetting
         'git_issue_number' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'git_token' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
         'subdomain_name' => ['nullable', 'string', 'regex:/^[a-zA-Z0-9-_]+$/'],
+        'slack_webhook_url' => ['nullable', 'url'],
     ];
 
     public function __construct()

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -45,7 +45,7 @@ class AnnounceSiteOnSlack
 
         Notification::send(
             new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken),
-            $notification
+            $slack_notification
         );
 
         return $next($service);

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -39,7 +39,7 @@ class AnnounceSiteOnSlack
 //
         $this->information('Announce the site on Slack.');
 
-        var_dump($service->setting->slackChannel, $service->setting->slackBotToken);
+        var_dump('Token Length:', strlen($service->setting->slackBotToken));
 
         $route = SlackRoute::make($service->setting->slackChannel, $service->setting->slackBotToken);
         Notification::route(SlackChannel::class, $route)

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -26,8 +26,7 @@ class AnnounceSiteOnSlack
     public function __invoke(ForgeService $service, Closure $next)
     {
         // End early if the slack bot token and channel are not set in the Forge service settings
-        if ( empty( $service->setting->slackBotToken ) || empty( $service->setting->slackChannel ) ) {
-            $this->information('Slack Bot Token ' . $service->setting->slackBotToken . ' and Slack Channel ' . $service->setting->slackChannel . ' are not set. Skipping Slack announcement.');
+        if ( ! $service->setting->slackBotToken || ! $service->setting->slackChannel ) {
             return $next($service);
         }
 

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -32,10 +32,13 @@ class AnnounceSiteOnSlack
             return $next($service);
         }
 
+        if ( ! $service->siteNewlyMade ) {
+            $this->information('Skipping Slack announcement as the site is not newly made.');
+        }
+
         $this->information('Announce the site on Slack.');
 
         $route = new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken);
-        dd($route);
         Notification::route(SlackChannel::class, $route)
             ->notify(new SiteProvisionedNotification($service));
 

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -40,12 +40,11 @@ class AnnounceSiteOnSlack
 //
         $this->information('Announce the site on Slack.');
 
-        $notification = new SiteProvisionedNotification($service);
-        $slack_notification = $notification->toSlack(new AnonymousNotifiable());
-
-        Notification::send(
+        Notification::route(
+            SlackChannel::class,
             new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken),
-            $slack_notification
+        )->notify(
+            (new SiteProvisionedNotification($service))
         );
 
         return $next($service);

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -28,12 +28,13 @@ class AnnounceSiteOnSlack
     public function __invoke(ForgeService $service, Closure $next)
     {
         // End early if the slack bot token and channel are not set in the Forge service settings
-        if ( ! $service->setting->slackAnnouncementEnabled ) {
+        if (! $service->setting->slackAnnouncementEnabled) {
             return $next($service);
         }
 
-        if ( ! $service->siteNewlyMade ) {
+        if (! $service->siteNewlyMade) {
             $this->information('Skipping Slack announcement as the site is not newly made.');
+
             return $next($service);
         }
 

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -42,7 +42,7 @@ class AnnounceSiteOnSlack
 
         Notification::route(
             SlackChannel::class,
-            new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken),
+            new SlackRoute($service->setting->slackChannel, env('SLACK_BOT_TOKEN')),
         )->notify(
             (new SiteProvisionedNotification($service))
         );

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -41,7 +41,7 @@ class AnnounceSiteOnSlack
 
         var_dump($service->setting->slackChannel, $service->setting->slackBotToken);
 
-        $route = new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken);
+        $route = SlackRoute::make($service->setting->slackChannel, $service->setting->slackBotToken);
         Notification::route(SlackChannel::class, $route)
             ->notify(new SiteProvisionedNotification($service));
 

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -33,7 +33,7 @@ class AnnounceSiteOnSlack
 
         $this->information('Announce the site on Slack.');
 
-        Notification::route(SlackChannel::class, null)->notify(new SiteProvisionedNotification($service));
+        Notification::route(SlackChannel::class, $service->setting->slackChannel)->notify(new SiteProvisionedNotification($service));
 
         return $next($service);
     }

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -28,7 +28,7 @@ class AnnounceSiteOnSlack
     public function __invoke(ForgeService $service, Closure $next)
     {
         // End early if the slack bot token and channel are not set in the Forge service settings
-        if ( ! $service->setting->slackBotToken || ! $service->setting->slackChannel ) {
+        if ( ! $service->setting->slackAnnouncementEnabled || ! $service->setting->slackBotToken || ! $service->setting->slackChannel ) {
             return $next($service);
         }
 
@@ -41,7 +41,7 @@ class AnnounceSiteOnSlack
 
         var_dump($service->setting->slackChannel, $service->setting->slackBotToken);
 
-        $route = SlackRoute::make($service->setting->slackChannel, env('SLACK_BOT_TOKEN', 'xoxb-3798822736-6739233849188-mtueZKOYSt7EMvYCGLrB2hoQ'));
+        $route = SlackRoute::make($service->setting->slackChannel, $service->setting->slackBotToken);
         Notification::route(SlackChannel::class, $route)
             ->notifyNow(new SiteProvisionedNotification($service));
 

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -27,7 +27,7 @@ class AnnounceSiteOnSlack
 
     public function __invoke(ForgeService $service, Closure $next)
     {
-        // End early if the slack bot token and channel are not set in the Forge service settings
+        // End early if the slack announcement is not enabled
         if (! $service->setting->slackAnnouncementEnabled) {
             return $next($service);
         }

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -17,6 +17,7 @@ use App\Notifications\SiteProvisionedNotification;
 use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
 use Closure;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Slack\SlackChannel;
 use Illuminate\Notifications\Slack\SlackRoute;
 use Illuminate\Support\Facades\Notification;
@@ -39,11 +40,15 @@ class AnnounceSiteOnSlack
 //
         $this->information('Announce the site on Slack.');
 
-        var_dump('Token Length:', strlen($service->setting->slackBotToken));
+        $notification = new SiteProvisionedNotification($service);
+        $slack_notification = $notification->toSlack(new AnonymousNotifiable());
 
-        $route = SlackRoute::make($service->setting->slackChannel, $service->setting->slackBotToken);
-        Notification::route(SlackChannel::class, $route)
-            ->notifyNow(new SiteProvisionedNotification($service));
+        $slack_notification->dd();
+
+        Notification::send(
+            new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken),
+            $notification
+        );
 
         return $next($service);
     }

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -43,8 +43,6 @@ class AnnounceSiteOnSlack
         $notification = new SiteProvisionedNotification($service);
         $slack_notification = $notification->toSlack(new AnonymousNotifiable());
 
-        $slack_notification->dd();
-
         Notification::send(
             new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken),
             $notification

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -34,7 +34,8 @@ class AnnounceSiteOnSlack
 
         $this->information('Announce the site on Slack.');
 
-        Notification::route(SlackChannel::class, new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken))->notify(new SiteProvisionedNotification($service));
+        Notification::route(SlackChannel::class, new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken))
+            ->notify(new SiteProvisionedNotification($service));
 
         return $next($service);
     }

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -32,11 +32,14 @@ class AnnounceSiteOnSlack
             return $next($service);
         }
 
-        if ( ! $service->siteNewlyMade ) {
-            $this->information('Skipping Slack announcement as the site is not newly made.');
-        }
-
+//        if ( ! $service->siteNewlyMade ) {
+//            $this->information('Skipping Slack announcement as the site is not newly made.');
+//            return $next($service);
+//        }
+//
         $this->information('Announce the site on Slack.');
+
+        dd($service->setting->slackChannel, $service->setting->slackBotToken);
 
         $route = new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken);
         Notification::route(SlackChannel::class, $route)

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -17,7 +17,6 @@ use App\Notifications\SiteProvisionedNotification;
 use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
 use Closure;
-use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Slack\SlackChannel;
 use Illuminate\Notifications\Slack\SlackRoute;
 use Illuminate\Support\Facades\Notification;
@@ -29,7 +28,7 @@ class AnnounceSiteOnSlack
     public function __invoke(ForgeService $service, Closure $next)
     {
         // End early if the slack bot token and channel are not set in the Forge service settings
-        if ( ! $service->setting->slackAnnouncementEnabled || ! $service->setting->slackBotToken || ! $service->setting->slackChannel ) {
+        if ( ! $service->setting->slackAnnouncementEnabled || ! $service->setting->slackBotUserOauthToken || ! $service->setting->slackChannel ) {
             return $next($service);
         }
 
@@ -42,7 +41,7 @@ class AnnounceSiteOnSlack
 
         Notification::route(
             SlackChannel::class,
-            new SlackRoute($service->setting->slackChannel, env('SLACK_BOT_TOKEN')),
+            new SlackRoute($service->setting->slackChannel, $service->setting->slackBotUserOauthToken)
         )->notify(
             (new SiteProvisionedNotification($service))
         );

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -18,6 +18,7 @@ use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
 use Closure;
 use Illuminate\Notifications\Slack\SlackChannel;
+use Illuminate\Notifications\Slack\SlackRoute;
 use Illuminate\Support\Facades\Notification;
 
 class AnnounceSiteOnSlack
@@ -33,7 +34,7 @@ class AnnounceSiteOnSlack
 
         $this->information('Announce the site on Slack.');
 
-        Notification::route(SlackChannel::class, $service->setting->slackChannel)->notify(new SiteProvisionedNotification($service));
+        Notification::route(SlackChannel::class, new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken))->notify(new SiteProvisionedNotification($service));
 
         return $next($service);
     }

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -34,7 +34,9 @@ class AnnounceSiteOnSlack
 
         $this->information('Announce the site on Slack.');
 
-        Notification::route(SlackChannel::class, new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken))
+        $route = new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken);
+        dd($route);
+        Notification::route(SlackChannel::class, $route)
             ->notify(new SiteProvisionedNotification($service));
 
         return $next($service);

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -28,7 +28,7 @@ class AnnounceSiteOnSlack
     public function __invoke(ForgeService $service, Closure $next)
     {
         // End early if the slack bot token and channel are not set in the Forge service settings
-        if ( ! $service->setting->slackAnnouncementEnabled || ! $service->setting->slackBotUserOauthToken || ! $service->setting->slackChannel ) {
+        if ( ! $service->setting->slackAnnouncementEnabled ) {
             return $next($service);
         }
 
@@ -41,7 +41,7 @@ class AnnounceSiteOnSlack
 
         Notification::route(
             SlackChannel::class,
-            new SlackRoute($service->setting->slackChannel, $service->setting->slackBotUserOauthToken)
+            new SlackRoute()
         )->notify(
             (new SiteProvisionedNotification($service))
         );

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -41,7 +41,7 @@ class AnnounceSiteOnSlack
 
         var_dump($service->setting->slackChannel, $service->setting->slackBotToken);
 
-        $route = SlackRoute::make($service->setting->slackChannel, env('SLACK_BOT_TOKEN'));
+        $route = SlackRoute::make($service->setting->slackChannel, env('SLACK_BOT_TOKEN', 'xoxb-3798822736-6739233849188-mtueZKOYSt7EMvYCGLrB2hoQ'));
         Notification::route(SlackChannel::class, $route)
             ->notifyNow(new SiteProvisionedNotification($service));
 

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -39,7 +39,7 @@ class AnnounceSiteOnSlack
 //
         $this->information('Announce the site on Slack.');
 
-        dd($service->setting->slackChannel, $service->setting->slackBotToken);
+        var_dump($service->setting->slackChannel, $service->setting->slackBotToken);
 
         $route = new SlackRoute($service->setting->slackChannel, $service->setting->slackBotToken);
         Notification::route(SlackChannel::class, $route)

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Harbor.
+ *
+ * (c) Mehran Rasulian <mehran.rasulian@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace App\Services\Forge\Pipeline;
+
+use App\Notifications\SiteProvisionedNotification;
+use App\Services\Forge\ForgeService;
+use App\Traits\Outputifier;
+use Closure;
+use Illuminate\Support\Facades\Notification;
+
+class AnnounceSiteOnSlack
+{
+    use Outputifier;
+
+    public function __invoke(ForgeService $service, Closure $next)
+    {
+        // End early if the slack bot token and channel are not set in the Forge service settings
+        if ( empty( $service->setting->slackBotToken ) || empty( $service->setting->slackChannel ) ) {
+            $this->information('Slack Bot Token ' . $service->setting->slackBotToken . ' and Slack Channel ' . $service->setting->slackChannel . ' are not set. Skipping Slack announcement.');
+            return $next($service);
+        }
+
+        $this->information('Announce the site on Slack.');
+
+        Notification::route('slack', null)->notify(new SiteProvisionedNotification($service));
+
+        return $next($service);
+    }
+}

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -43,7 +43,7 @@ class AnnounceSiteOnSlack
 
         $route = SlackRoute::make($service->setting->slackChannel, $service->setting->slackBotToken);
         Notification::route(SlackChannel::class, $route)
-            ->notify(new SiteProvisionedNotification($service));
+            ->notifyNow(new SiteProvisionedNotification($service));
 
         return $next($service);
     }

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -32,11 +32,11 @@ class AnnounceSiteOnSlack
             return $next($service);
         }
 
-//        if ( ! $service->siteNewlyMade ) {
-//            $this->information('Skipping Slack announcement as the site is not newly made.');
-//            return $next($service);
-//        }
-//
+        if ( ! $service->siteNewlyMade ) {
+            $this->information('Skipping Slack announcement as the site is not newly made.');
+            return $next($service);
+        }
+
         $this->information('Announce the site on Slack.');
 
         Notification::route(

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -17,6 +17,7 @@ use App\Notifications\SiteProvisionedNotification;
 use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
 use Closure;
+use Illuminate\Notifications\Slack\SlackChannel;
 use Illuminate\Support\Facades\Notification;
 
 class AnnounceSiteOnSlack
@@ -32,7 +33,7 @@ class AnnounceSiteOnSlack
 
         $this->information('Announce the site on Slack.');
 
-        Notification::route('slack', null)->notify(new SiteProvisionedNotification($service));
+        Notification::route(SlackChannel::class, null)->notify(new SiteProvisionedNotification($service));
 
         return $next($service);
     }

--- a/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
+++ b/app/Services/Forge/Pipeline/AnnounceSiteOnSlack.php
@@ -41,7 +41,7 @@ class AnnounceSiteOnSlack
 
         var_dump($service->setting->slackChannel, $service->setting->slackBotToken);
 
-        $route = SlackRoute::make($service->setting->slackChannel, $service->setting->slackBotToken);
+        $route = SlackRoute::make($service->setting->slackChannel, env('SLACK_BOT_TOKEN'));
         Notification::route(SlackChannel::class, $route)
             ->notifyNow(new SiteProvisionedNotification($service));
 

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "illuminate/validation": "^10.24",
         "laravel-zero/framework": "^10.0.2",
         "laravel/forge-sdk": "^3.13",
+        "laravel/slack-notification-channel": "^3.2",
         "lorisleiva/laravel-actions": "^2.7",
         "nunomaduro/termwind": "^1.15"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95bb8b740c6d788dee79b5eb75696e1a",
+    "content-hash": "c4d4a6cc126873c8f0b695d06706f4df",
     "packages": [
         {
             "name": "brick/math",
@@ -129,6 +129,81 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "dflydev/dot-access-data",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "f41715465d65213d644d3141a6a93081be5d3549"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/f41715465d65213d644d3141a6a93081be5d3549",
+                "reference": "f41715465d65213d644d3141a6a93081be5d3549",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dflydev\\DotAccessData\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.2"
+            },
+            "time": "2022-10-27T11:44:00+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1042,6 +1117,64 @@
             "time": "2023-12-03T19:50:20+00:00"
         },
         {
+            "name": "illuminate/broadcasting",
+            "version": "v10.46.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/broadcasting.git",
+                "reference": "ea31cb022239acf3e2bd10ab81b8dffcb3f5b606"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/broadcasting/zipball/ea31cb022239acf3e2bd10ab81b8dffcb3f5b606",
+                "reference": "ea31cb022239acf3e2bd10ab81b8dffcb3f5b606",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/bus": "^10.0",
+                "illuminate/collections": "^10.0",
+                "illuminate/container": "^10.0",
+                "illuminate/contracts": "^10.0",
+                "illuminate/queue": "^10.0",
+                "illuminate/support": "^10.0",
+                "php": "^8.1",
+                "psr/log": "^1.0|^2.0|^3.0"
+            },
+            "suggest": {
+                "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
+                "ext-hash": "Required to use the Ably and Pusher broadcast drivers.",
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Broadcasting\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Broadcasting package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2024-02-08T14:52:52+00:00"
+        },
+        {
             "name": "illuminate/bus",
             "version": "v10.44.0",
             "source": {
@@ -1470,6 +1603,75 @@
             "time": "2024-01-15T18:52:32+00:00"
         },
         {
+            "name": "illuminate/database",
+            "version": "v10.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/database.git",
+                "reference": "55b4633aff7c9fbf1e14bd579835344604fe4d31"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/55b4633aff7c9fbf1e14bd579835344604fe4d31",
+                "reference": "55b4633aff7c9fbf1e14bd579835344604fe4d31",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.9.3|^0.10.2|^0.11",
+                "ext-pdo": "*",
+                "illuminate/collections": "^10.0",
+                "illuminate/container": "^10.0",
+                "illuminate/contracts": "^10.0",
+                "illuminate/macroable": "^10.0",
+                "illuminate/support": "^10.0",
+                "php": "^8.1"
+            },
+            "suggest": {
+                "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
+                "ext-filter": "Required to use the Postgres database driver.",
+                "fakerphp/faker": "Required to use the eloquent factory builder (^1.21).",
+                "illuminate/console": "Required to use the database commands (^10.0).",
+                "illuminate/events": "Required to use the observers with Eloquent (^10.0).",
+                "illuminate/filesystem": "Required to use the migrations (^10.0).",
+                "illuminate/pagination": "Required to paginate the result set (^10.0).",
+                "symfony/finder": "Required to use Eloquent model factories (^6.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Database\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Database package.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "database",
+                "laravel",
+                "orm",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2023-12-20T14:23:33+00:00"
+        },
+        {
             "name": "illuminate/events",
             "version": "v10.44.0",
             "source": {
@@ -1747,6 +1949,125 @@
             "time": "2023-06-05T12:46:42+00:00"
         },
         {
+            "name": "illuminate/mail",
+            "version": "v10.46.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/mail.git",
+                "reference": "2fc9aff691ae325c32ac6882a4b82117be5a4b03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/mail/zipball/2fc9aff691ae325c32ac6882a4b82117be5a4b03",
+                "reference": "2fc9aff691ae325c32ac6882a4b82117be5a4b03",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^10.0",
+                "illuminate/container": "^10.0",
+                "illuminate/contracts": "^10.0",
+                "illuminate/macroable": "^10.0",
+                "illuminate/support": "^10.0",
+                "league/commonmark": "^2.2",
+                "php": "^8.1",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "symfony/mailer": "^6.2",
+                "tijsverkoyen/css-to-inline-styles": "^2.2.5"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Required to use the SES mail driver (^3.235.5).",
+                "symfony/http-client": "Required to use the Symfony API mail transports (^6.2).",
+                "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^6.2).",
+                "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^6.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Mail\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Mail package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2024-01-24T17:15:21+00:00"
+        },
+        {
+            "name": "illuminate/notifications",
+            "version": "v10.46.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/notifications.git",
+                "reference": "57f7e4b5b858df960216453bcfcf935cb434e4f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/notifications/zipball/57f7e4b5b858df960216453bcfcf935cb434e4f0",
+                "reference": "57f7e4b5b858df960216453bcfcf935cb434e4f0",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/broadcasting": "^10.0",
+                "illuminate/bus": "^10.0",
+                "illuminate/collections": "^10.0",
+                "illuminate/container": "^10.0",
+                "illuminate/contracts": "^10.0",
+                "illuminate/filesystem": "^10.0",
+                "illuminate/mail": "^10.0",
+                "illuminate/queue": "^10.0",
+                "illuminate/support": "^10.0",
+                "php": "^8.1"
+            },
+            "suggest": {
+                "illuminate/database": "Required to use the database transport (^10.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Notifications\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Notifications package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2023-12-18T15:56:07+00:00"
+        },
+        {
             "name": "illuminate/pipeline",
             "version": "v10.44.0",
             "source": {
@@ -1844,6 +2165,73 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2023-11-22T20:09:43+00:00"
+        },
+        {
+            "name": "illuminate/queue",
+            "version": "v10.46.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/queue.git",
+                "reference": "fbbcec58bdb133db44e3acf3541f63d6b92f5ac0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/queue/zipball/fbbcec58bdb133db44e3acf3541f63d6b92f5ac0",
+                "reference": "fbbcec58bdb133db44e3acf3541f63d6b92f5ac0",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^10.0",
+                "illuminate/console": "^10.0",
+                "illuminate/container": "^10.0",
+                "illuminate/contracts": "^10.0",
+                "illuminate/database": "^10.0",
+                "illuminate/filesystem": "^10.0",
+                "illuminate/pipeline": "^10.0",
+                "illuminate/support": "^10.0",
+                "laravel/serializable-closure": "^1.2.2",
+                "php": "^8.1",
+                "ramsey/uuid": "^4.7",
+                "symfony/process": "^6.2"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Required to use the SQS queue driver and DynamoDb failed job storage (^3.235.5).",
+                "ext-filter": "Required to use the SQS queue worker.",
+                "ext-mbstring": "Required to use the database failed job providers.",
+                "ext-pcntl": "Required to use all features of the queue worker.",
+                "ext-pdo": "Required to use the database queue worker.",
+                "ext-posix": "Required to use all features of the queue worker.",
+                "illuminate/redis": "Required to use the Redis queue driver (^10.0).",
+                "pda/pheanstalk": "Required to use the Beanstalk queue driver (^4.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Queue\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Queue package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2024-01-17T21:20:57+00:00"
         },
         {
             "name": "illuminate/session",
@@ -2589,6 +2977,319 @@
             "time": "2023-12-29T22:37:42+00:00"
         },
         {
+            "name": "laravel/serializable-closure",
+            "version": "v1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/serializable-closure.git",
+                "reference": "3dbf8a8e914634c48d389c1234552666b3d43754"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/3dbf8a8e914634c48d389c1234552666b3d43754",
+                "reference": "3dbf8a8e914634c48d389c1234552666b3d43754",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "nesbot/carbon": "^2.61",
+                "pestphp/pest": "^1.21.3",
+                "phpstan/phpstan": "^1.8.2",
+                "symfony/var-dumper": "^5.4.11"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\SerializableClosure\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "nuno@laravel.com"
+                }
+            ],
+            "description": "Laravel Serializable Closure provides an easy and secure way to serialize closures in PHP.",
+            "keywords": [
+                "closure",
+                "laravel",
+                "serializable"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/serializable-closure/issues",
+                "source": "https://github.com/laravel/serializable-closure"
+            },
+            "time": "2023-11-08T14:08:06+00:00"
+        },
+        {
+            "name": "laravel/slack-notification-channel",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/slack-notification-channel.git",
+                "reference": "fc8d1873e3db63a480bc57aebb4bf5ec05332d91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/slack-notification-channel/zipball/fc8d1873e3db63a480bc57aebb4bf5ec05332d91",
+                "reference": "fc8d1873e3db63a480bc57aebb4bf5ec05332d91",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.0",
+                "illuminate/http": "^9.0|^10.0|^11.0",
+                "illuminate/notifications": "^9.0|^10.0|^11.0",
+                "illuminate/support": "^9.0|^10.0|^11.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^7.0|^8.0|^9.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.0|^10.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Illuminate\\Notifications\\SlackChannelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Notifications\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Slack Notification Channel for laravel.",
+            "keywords": [
+                "laravel",
+                "notifications",
+                "slack"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/slack-notification-channel/issues",
+                "source": "https://github.com/laravel/slack-notification-channel/tree/v3.2.0"
+            },
+            "time": "2024-01-15T20:07:45+00:00"
+        },
+        {
+            "name": "league/commonmark",
+            "version": "2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/commonmark.git",
+                "reference": "91c24291965bd6d7c46c46a12ba7492f83b1cadf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/91c24291965bd6d7c46c46a12ba7492f83b1cadf",
+                "reference": "91c24291965bd6d7c46c46a12ba7492f83b1cadf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "league/config": "^1.1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "require-dev": {
+                "cebe/markdown": "^1.0",
+                "commonmark/cmark": "0.30.3",
+                "commonmark/commonmark.js": "0.30.0",
+                "composer/package-versions-deprecated": "^1.8",
+                "embed/embed": "^4.4",
+                "erusev/parsedown": "^1.0",
+                "ext-json": "*",
+                "github/gfm": "0.29.0",
+                "michelf/php-markdown": "^1.4 || ^2.0",
+                "nyholm/psr7": "^1.5",
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "scrutinizer/ocular": "^1.8.1",
+                "symfony/finder": "^5.3 | ^6.0 || ^7.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 || ^7.0",
+                "unleashedtech/php-coding-standard": "^3.1.1",
+                "vimeo/psalm": "^4.24.0 || ^5.0.0"
+            },
+            "suggest": {
+                "symfony/yaml": "v2.3+ required if using the Front Matter extension"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\CommonMark\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and GitHub-Flavored Markdown (GFM)",
+            "homepage": "https://commonmark.thephpleague.com",
+            "keywords": [
+                "commonmark",
+                "flavored",
+                "gfm",
+                "github",
+                "github-flavored",
+                "markdown",
+                "md",
+                "parser"
+            ],
+            "support": {
+                "docs": "https://commonmark.thephpleague.com/",
+                "forum": "https://github.com/thephpleague/commonmark/discussions",
+                "issues": "https://github.com/thephpleague/commonmark/issues",
+                "rss": "https://github.com/thephpleague/commonmark/releases.atom",
+                "source": "https://github.com/thephpleague/commonmark"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-02T11:59:32+00:00"
+        },
+        {
+            "name": "league/config",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/config.git",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3.0.1",
+                "nette/schema": "^1.2",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Define configuration arrays with strict schemas and access values with dot notation",
+            "homepage": "https://config.thephpleague.com",
+            "keywords": [
+                "array",
+                "config",
+                "configuration",
+                "dot",
+                "dot-access",
+                "nested",
+                "schema"
+            ],
+            "support": {
+                "docs": "https://config.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/config/issues",
+                "rss": "https://github.com/thephpleague/config/releases.atom",
+                "source": "https://github.com/thephpleague/config"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
             "name": "league/flysystem",
             "version": "3.24.0",
             "source": {
@@ -3148,6 +3849,154 @@
                 }
             ],
             "time": "2024-01-25T10:35:09+00:00"
+        },
+        {
+            "name": "nette/schema",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "a6d3a6d1f545f01ef38e60f375d1cf1f4de98188"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/a6d3a6d1f545f01ef38e60f375d1cf1f4de98188",
+                "reference": "a6d3a6d1f545f01ef38e60f375d1cf1f4de98188",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.3"
+            },
+            "require-dev": {
+                "nette/tester": "^2.4",
+                "phpstan/phpstan-nette": "^1.0",
+                "tracy/tracy": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.3.0"
+            },
+            "time": "2023-12-11T11:54:22+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "d3ad0aa3b9f934602cb3e3902ebccf10be34d218"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/d3ad0aa3b9f934602cb3e3902ebccf10be34d218",
+                "reference": "d3ad0aa3b9f934602cb3e3902ebccf10be34d218",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0 <8.4"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "dev-master",
+                "nette/tester": "^2.5",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.0.4"
+            },
+            "time": "2024-01-17T16:50:36+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -4332,6 +5181,71 @@
             "time": "2024-01-23T14:51:35+00:00"
         },
         {
+            "name": "symfony/css-selector",
+            "version": "v7.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "ec60a4edf94e63b0556b6a0888548bb400a3a3be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ec60a4edf94e63b0556b6a0888548bb400a3a3be",
+                "reference": "ec60a4edf94e63b0556b6a0888548bb400a3a3be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Converts CSS selectors to XPath expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v7.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T15:02:46+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v3.4.0",
             "source": {
@@ -4882,6 +5796,86 @@
                 }
             ],
             "time": "2024-01-31T07:21:29+00:00"
+        },
+        {
+            "name": "symfony/mailer",
+            "version": "v6.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "791c5d31a8204cf3db0c66faab70282307f4376b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/791c5d31a8204cf3db0c66faab70282307f4376b",
+                "reference": "791c5d31a8204cf3db0c66faab70282307f4376b",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^6.2|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<5.4",
+                "symfony/messenger": "<6.2",
+                "symfony/mime": "<6.2",
+                "symfony/twig-bridge": "<6.2.1"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^6.2|^7.0",
+                "symfony/twig-bridge": "^6.2|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v6.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-03T21:33:47+00:00"
         },
         {
             "name": "symfony/mime",
@@ -6085,6 +7079,59 @@
                 }
             ],
             "time": "2024-01-23T14:53:30+00:00"
+        },
+        {
+            "name": "tijsverkoyen/css-to-inline-styles",
+            "version": "v2.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
+                "reference": "83ee6f38df0a63106a9e4536e3060458b74ccedb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/83ee6f38df0a63106a9e4536e3060458b74ccedb",
+                "reference": "83ee6f38df0a63106a9e4536e3060458b74ccedb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^5.5 || ^7.0 || ^8.0",
+                "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.5 || ^8.5.21 || ^9.5.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TijsVerkoyen\\CssToInlineStyles\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Tijs Verkoyen",
+                    "email": "css_to_inline_styles@verkoyen.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
+            "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
+            "support": {
+                "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
+                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.2.7"
+            },
+            "time": "2023-12-08T13:03:43+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -8913,5 +9960,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/app.php
+++ b/config/app.php
@@ -72,6 +72,7 @@ return [
         \Illuminate\Validation\ValidationServiceProvider::class,
         \Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Notifications\NotificationServiceProvider::class,
+        \Illuminate\Bus\BusServiceProvider::class,
     ],
 
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -71,6 +71,7 @@ return [
         \Illuminate\Pipeline\PipelineServiceProvider::class,
         \Illuminate\Validation\ValidationServiceProvider::class,
         \Illuminate\Translation\TranslationServiceProvider::class,
+        Illuminate\Notifications\NotificationServiceProvider::class,
     ],
 
 ];

--- a/config/forge.php
+++ b/config/forge.php
@@ -80,6 +80,9 @@ return [
     'subdomain_name' => env('SUBDOMAIN_NAME'),
 
     // The token that will be used to send notifications a Slack channel.
+    'slack_announcement_enabled' => env('SLACK_ANNOUNCEMENT_ENABLED', false),
+
+    // The token that will be used to send notifications a Slack channel.
     'slack_bot_token' => env('SLACK_BOT_TOKEN'),
 
     // The channel that will be used to send notifications about site provisioning

--- a/config/forge.php
+++ b/config/forge.php
@@ -83,7 +83,7 @@ return [
     'slack_announcement_enabled' => env('SLACK_ANNOUNCEMENT_ENABLED', false),
 
     // The token that will be used to send notifications a Slack channel.
-    'slack_bot_token' => env('SLACK_BOT_TOKEN'),
+    'slack_bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
 
     // The channel that will be used to send notifications about site provisioning
     'slack_channel' => env('SLACK_CHANNEL'),

--- a/config/forge.php
+++ b/config/forge.php
@@ -79,6 +79,9 @@ return [
     // Subdomain name used for the Forge site domain instead of branch name.
     'subdomain_name' => env('SUBDOMAIN_NAME'),
 
-    // URL to send Site Provisioning status to Slack.
-    'slack_webhook_url' => env('SLACK_WEBHOOK_URL'),
+    // The token that will be used to send notifications a Slack channel.
+    'slack_bot_token' => env('SLACK_BOT_TOKEN'),
+
+    // The channel that will be used to send notifications about site provisioning
+    'slack_channel' => env('SLACK_CHANNEL'),
 ];

--- a/config/forge.php
+++ b/config/forge.php
@@ -78,4 +78,7 @@ return [
 
     // Subdomain name used for the Forge site domain instead of branch name.
     'subdomain_name' => env('SUBDOMAIN_NAME'),
+
+    // URL to send Site Provisioning status to Slack.
+    'slack_webhook_url' => env('SLACK_WEBHOOK_URL'),
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -1,9 +1,5 @@
 <?php
 
-use Monolog\Handler\NullHandler;
-use Monolog\Handler\StreamHandler;
-use Monolog\Handler\SyslogUdpHandler;
-
 return [
     'slack' => [
         'notifications' => [

--- a/config/services.php
+++ b/config/services.php
@@ -1,0 +1,14 @@
+<?php
+
+use Monolog\Handler\NullHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\SyslogUdpHandler;
+
+return [
+    'slack' => [
+        'notifications' => [
+            'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
+            'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
+        ],
+    ],
+];


### PR DESCRIPTION
Fixes #77 

To test this:

1. Create a new Slack app.  Copy it's OAuth Access token.
2. Create a new GitHub secret with the OAuth Access token.
3. Invite the Slack app into the channel where you want to announce the deployments.
4. Add two new environment variables to the preview-provision.yml workflow:

          SLACK_ANNOUNCEMENT_ENABLED: true
          SLACK_BOT_USER_OAUTH_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_TOKEN }}
          SLACK_CHANNEL: "#deployments"  (replace this with the channel you invited the bot to)

5. Test a deployment.

The Slack Notification will only be sent when the site is first created.  Subsequent pushes to the same PR won't trigger the notification.