### PR TITLE
Override database name w/ FORGE_DB_NAME environment variable

### DIFF
--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -118,6 +118,11 @@ class ForgeSetting
     public bool $dbCreationRequired;
 
     /**
+     * The name of the database to be created
+     */
+    public ?string $dbName;
+
+    /**
      * Flag to auto-source environment variables in deployment.
      */
     public bool $autoSourceRequired;
@@ -196,6 +201,7 @@ class ForgeSetting
         'site_isolation_required' => ['boolean'],
         'job_scheduler_required' => ['boolean'],
         'db_creation_required' => ['boolean'],
+        'db_name' => ['nullable', 'string'],
         'auto_source_required' => ['boolean'],
         'ssl_required' => ['boolean'],
         'wait_on_ssl' => ['boolean'],

--- a/app/Services/Forge/Pipeline/CreateDatabase.php
+++ b/app/Services/Forge/Pipeline/CreateDatabase.php
@@ -29,7 +29,7 @@ class CreateDatabase
         }
 
         $dbPassword = Str::random(16);
-        $dbName = $service->getStandardizedBranchName();
+        $dbName = $service->setting->dbName ?? $service->getStandardizedBranchName();
 
         if (! $this->databaseExists($service, $dbName)) {
             $this->information('Creating database.');

--- a/config/forge.php
+++ b/config/forge.php
@@ -55,6 +55,9 @@ return [
     // Flag to enable Quick Deploy (default: true).
     'quick_deploy' => env('FORGE_QUICK_DEPLOY', false),
 
+    // Override default database and database username, if needed. Defaults to the site name.
+    'db_name' => env('FORGE_DB_NAME', null),
+
     // Flag to enable SSL certification (default: false).
     'ssl_required' => env('FORGE_SSL_REQUIRED', false),
 


### PR DESCRIPTION
Allows the database name to be overridden. 

# Use Case 

I'm spinning up 2 Forge sites for every pull request against my repository's main branch.  One site is for the QA and UAT teams to do their testing in (a regular preview site), and the other one is spun up for running Dusk integration tests. 

Both of these sites are being provisioned on the same Forge-controlled AWS EC2 instance.

Let's call the branch we're working with ***acme*** .

# Setup

There's no subdomain set on the preview environment's provisioning.  It will use the branch name by default. 

On the dusk environment, I've changed the domain in the provisioning script so that it has "-dusk" appended to it:

          SUBDOMAIN_NAME: ${{ format('"{0}-dusk"', github.head_ref) }}

# Problem 

Both sites end up with "acme" as the MySQL database and usernames. 

# Solution

Added a new Forge setting called dbName (environment variable FORGE_DB_NAME) that, if present, gets used instead of the username/database name created by formatting the branch name. 
