### PR TITLE
Changed getSiteLink to use protocol based on sslRequired variable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.vagrant
 .phpunit.result.cache
 .env
+.DS_Store

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -142,7 +142,7 @@ class ForgeService
             return $this->setting->environmentUrl;
         }
 
-        return ($this->site->isSecured ? 'https://' : 'http://').$this->site->name;
+        return ($this->setting->sslRequired ? 'https://' : 'http://').$this->site->name;
     }
 
     public function siteDirectory(): string

--- a/tests/Unit/Services/Forge/ForgeServiceTest.php
+++ b/tests/Unit/Services/Forge/ForgeServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Services\Forge\ForgeService;
+use App\Services\Forge\ForgeSetting;
+use Laravel\Forge\Forge;
+use Laravel\Forge\Resources\Site;
+
+test('it gets the site link using the environment URL when explicity provided', function () {
+
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->environmentUrl = 'https://foo.bar';
+    $setting->timeoutSeconds = 0;
+
+    $service = new ForgeService($setting,  new Forge);
+
+    expect($service->getSiteLink())->toBe('https://foo.bar');
+});
+
+test('it gets the site link using HTTPS when SSL is required', function () {
+
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->environmentUrl = null;
+    $setting->sslRequired = true;
+    $setting->timeoutSeconds = 0;
+
+    $service = new ForgeService($setting,  new Forge);
+
+    $site = mock(Site::class);
+    $site->name = 'foo.bar';
+    $service->setSite($site);
+
+    expect($service->getSiteLink())->toBe('https://foo.bar');
+});
+
+test('it gets the site link using HTTP when SSL is not required', function () {
+
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->environmentUrl = null;
+    $setting->sslRequired = false;
+    $setting->timeoutSeconds = 0;
+
+    $service = new ForgeService($setting,  new Forge);
+
+    $site = mock(Site::class);
+    $site->name = 'foo.bar';
+    $service->setSite($site);
+
+    expect($service->getSiteLink())->toBe('http://foo.bar');
+});


### PR DESCRIPTION
Closes #96 

This PR ensures the site link that is added to comments uses the protocol expected by the user, based on the FORGE_SSL_REQUIRED environment variable.

The rationale for this approach is to ensure the URL is independent of any SSL provisioning process (which may be successful / pending / failed). This means users requesting a secure URL will never receive an insecure one, even if the SSL cert has not yet finished provisioning or there's some misconfiguration elsewhere.