### PR TITLE
Add Site Isolation Username Setting

### DIFF
--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -83,6 +83,10 @@ class ForgeService
 
     public function getSiteIsolationUsername(): string
     {
+        if (!empty($this->setting->siteIsolationUsername)) {
+            return $this->setting->siteIsolationUsername;
+        }
+
         return GenerateStandardizedBranchName::run(
             $this->getFormattedBranchName()
         );

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -109,6 +109,11 @@ class ForgeSetting
     public bool $siteIsolationRequired;
 
     /**
+     * Username for the site isolation (default: formated branch name).
+     */
+    public ?string $siteIsolationUsername;
+
+    /**
      * Flag indicating if a job scheduler is needed.
      */
     public bool $jobSchedulerRequired;
@@ -223,6 +228,7 @@ class ForgeSetting
             'nginx_template' => ['nullable', 'int'],
             'quick_deploy' => ['boolean'],
             'site_isolation_required' => ['boolean'],
+            'site_isolation_username' => ['nullable', 'string'],
             'job_scheduler_required' => ['boolean'],
             'db_creation_required' => ['boolean'],
             'db_name' => ['nullable', 'string'],

--- a/config/forge.php
+++ b/config/forge.php
@@ -43,6 +43,9 @@ return [
     // Flag indicating if site isolation is needed (default: false).
     'site_isolation_required' => env('FORGE_SITE_ISOLATION', false),
 
+    // Username for the site isolation (default: formated branch name).
+    'site_isolation_username' => env('FORGE_SITE_ISOLATION_USERNAME', null),
+
     // Flag indicating if a job scheduler is needed (default: false).
     'job_scheduler_required' => env('FORGE_JOB_SCHEDULER', false),
 


### PR DESCRIPTION
This pull request introduces a new feature to support a configurable `site_isolation_username` setting.

This fixes #110

> [!NOTE]
> I added/tested this from the `v1.0.1` tag, as the main branch has errors in the `Outputifier` trait.