### PR TITLE
Add Forge webhook support

### DIFF
--- a/app/Commands/ProvisionCommand.php
+++ b/app/Commands/ProvisionCommand.php
@@ -16,6 +16,7 @@ namespace App\Commands;
 use App\Services\Forge\ForgeService;
 use App\Services\Forge\Pipeline\AnnounceSiteOnSlack;
 use App\Services\Forge\Pipeline\CreateDatabase;
+use App\Services\Forge\Pipeline\CreateWebhook;
 use App\Services\Forge\Pipeline\DeploySite;
 use App\Services\Forge\Pipeline\EnableInertiaSupport;
 use App\Services\Forge\Pipeline\EnableQuickDeploy;
@@ -57,6 +58,7 @@ class ProvisionCommand extends Command
                 UpdateEnvironmentVariables::class,
                 UpdateDeployScript::class,
                 DeploySite::class,
+                CreateWebhook::class,
                 RunOptionalCommands::class,
                 EnsureJobScheduled::class,
                 PutCommentOnPullRequest::class,

--- a/app/Services/Comments/MarkdownBuilder.php
+++ b/app/Services/Comments/MarkdownBuilder.php
@@ -17,6 +17,14 @@ class MarkdownBuilder
 {
     public function prepareBody(array $rows): string
     {
+        $environmentUrl = '';
+        foreach ($rows as $row) {
+            if ($row['name'] === 'Environment Url') {
+                $environmentUrl = $row['content'];
+                break;
+            }
+        }
+
         $body = [];
 
         foreach ($rows as $row) {
@@ -28,13 +36,8 @@ class MarkdownBuilder
             $body[] = "| **{$row['name']}** | $content |";
         }
 
-        return $this->getGitPrMarkdown($body);
-    }
-
-    private function getGitPrMarkdown(array $body): string
-    {
         return "# Harbor Preview Environment Details
-Hello! Here are the details of the preview environment for this pull request:
+Hello! Here are the details of the [PR preview]($environmentUrl) environment:
 
 | Service     | Location                |
 |-------------|-------------------------|\n"

--- a/app/Services/Comments/MarkdownBuilder.php
+++ b/app/Services/Comments/MarkdownBuilder.php
@@ -17,14 +17,6 @@ class MarkdownBuilder
 {
     public function prepareBody(array $rows): string
     {
-        $environmentUrl = '';
-        foreach ($rows as $row) {
-            if ($row['name'] === 'Environment Url') {
-                $environmentUrl = $row['content'];
-                break;
-            }
-        }
-
         $body = [];
 
         foreach ($rows as $row) {
@@ -36,8 +28,13 @@ class MarkdownBuilder
             $body[] = "| **{$row['name']}** | $content |";
         }
 
+        return $this->getGitPrMarkdown($body);
+    }
+
+    private function getGitPrMarkdown(array $body): string
+    {
         return "# Harbor Preview Environment Details
-Hello! Here are the details of the [PR preview]($environmentUrl) environment:
+Hello! Here are the details of the preview environment for this pull request:
 
 | Service     | Location                |
 |-------------|-------------------------|\n"

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -204,6 +204,11 @@ class ForgeSetting
      */
     public bool $githubCreateDeployKey;
 
+    /**
+     * The webhook URL to be added to the Forge site
+     */
+    public ?string $webhookUrl;
+
     public function __construct()
     {
         $this->init(config('forge'));
@@ -254,6 +259,7 @@ class ForgeSetting
             'git_token' => ['exclude_if:git_comment_enabled,false', 'required', 'string'],
             'subdomain_name' => ['nullable', 'string', 'regex:/^[a-zA-Z0-9-_]+$/'],
             'environment_url' => ['nullable', 'url'],
+            'webhook_url' => ['nullable', 'url'],
             'slack_announcement_enabled' => ['required', 'boolean'],
             'slack_bot_user_oauth_token' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],
             'slack_channel' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],

--- a/app/Services/Forge/Pipeline/CreateWebhook.php
+++ b/app/Services/Forge/Pipeline/CreateWebhook.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Harbor.
+ *
+ * (c) Mehran Rasulian <mehran.rasulian@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace App\Services\Forge\Pipeline;
+
+use App\Services\Forge\ForgeService;
+use App\Traits\Outputifier;
+use Closure;
+use Laravel\Forge\Exceptions\ValidationException;
+
+/**
+ * Creates a webhook for the Forge site.
+ *
+ * This pipeline step will create a webhook on the Forge site if a webhook URL
+ * is provided in the configuration. The webhook will be triggered whenever
+ * the site is deployed, allowing for integration with external services.
+ */
+class CreateWebhook
+{
+    use Outputifier;
+
+    public function __invoke(ForgeService $service, Closure $next)
+    {
+        if (! $service->setting->webhookUrl) {
+            return $next($service);
+        }
+
+        $this->information('Creating webhook for the site.');
+
+        try {
+            $service->forge->createWebhook(
+                $service->server->id,
+                $service->site->id,
+                ['url' => $service->setting->webhookUrl]
+            );
+        } catch (ValidationException $e) {
+            $this->warning(sprintf('Failed to create webhook: %s', $e->getMessage()));
+        }
+
+        return $next($service);
+    }
+}

--- a/config/forge.php
+++ b/config/forge.php
@@ -105,4 +105,7 @@ return [
 
     // Used to create a Forge daemon to start inertia ssr.
     'inertia_ssr_enabled' => env('INERTIA_SSR_ENABLED', false),
+
+    // The webhook URL to be added to the Forge site.
+    'webhook_url' => env('FORGE_WEBHOOK_URL'),
 ];


### PR DESCRIPTION
# Add Forge webhook support

Adds the ability to configure webhooks during site provisioning. When `FORGE_WEBHOOK_URL` is set, Harbor will automatically create a webhook on the Forge site.

## Usage

Add to your Harbor config:
```yaml
FORGE_WEBHOOK_URL: https://your-webhook-endpoint.com
```