### PR TITLE
Linear preview link integration

### DIFF
--- a/app/Services/Comments/MarkdownBuilder.php
+++ b/app/Services/Comments/MarkdownBuilder.php
@@ -17,6 +17,14 @@ class MarkdownBuilder
 {
     public function prepareBody(array $rows): string
     {
+        $environmentUrl = '';
+        foreach ($rows as $row) {
+            if ($row['name'] === 'Environment Url') {
+                $environmentUrl = $row['content'];
+                break;
+            }
+        }
+
         $body = [];
 
         foreach ($rows as $row) {
@@ -28,13 +36,8 @@ class MarkdownBuilder
             $body[] = "| **{$row['name']}** | $content |";
         }
 
-        return $this->getGitPrMarkdown($body);
-    }
-
-    private function getGitPrMarkdown(array $body): string
-    {
         return "# Harbor Preview Environment Details
-Hello! Here are the details of the preview environment for this pull request:
+Hello! Here are the details of the [PR preview]($environmentUrl) environment:
 
 | Service     | Location                |
 |-------------|-------------------------|\n"

--- a/app/Services/Comments/MarkdownBuilder.php
+++ b/app/Services/Comments/MarkdownBuilder.php
@@ -36,6 +36,12 @@ class MarkdownBuilder
             $body[] = "| **{$row['name']}** | $content |";
         }
 
+        return $this->getGitPrMarkdown($body);
+    }
+
+    private function getGitPrMarkdown(array $body): string
+    {
+
         return "# Harbor Preview Environment Details
 Hello! Here are the details of the [PR preview]($environmentUrl) environment:
 


### PR DESCRIPTION
# Linear Preview Link Integration

This PR modifies the GitHub PR automated comments to support Linear's Preview Link integration. When a PR is created, the preview link will now automatically appear in the connected Linear issue.

## Linear Documentation Reference
As per Linear's documentation, preview links are automatically detected when:
- PR descriptions/comments contain markdown links ending with "preview"
- https://linear.app/docs/github#pull-request-preview-links

## Changes
- Modified the PR comment format to include a "[PR preview]" link that Linear can detect

## Technical Details
- Updated `MarkdownBuilder` to include the preview link in the format Linear expects
- The preview link is now placed in the introduction text: `[PR preview](environment-url)`
- Maintained the existing table format for all environment details