### PR TITLE
Create queue workers on initial site provisioning

### DIFF
--- a/app/Actions/ParseQueueCommands.php
+++ b/app/Actions/ParseQueueCommands.php
@@ -13,20 +13,20 @@ class ParseQueueCommands
     use AsAction,
         Outputifier;
 
-    private string $signature = '{connection : The name of the queue connection to work}
-                                {--queue= : The names of the queues to work}
-                                {--timeout= : Maximum seconds a job can run}
-                                {--sleep=3 : Number of seconds to sleep when no job is available}
-                                {--delay= : The number of seconds to delay failed jobs}
-                                {--tries= : Number of times to attempt a job before logging it failed}
-                                {--php_version=php : PHP version to use}
-                                {--environment= : Environment to run the queue worker in}
-                                {--memory= : The memory limit in megabytes}
-                                {--directory= : Working directory}
-                                {--numprocs= : Number of workers to run}
-                                {--stopwaitsecs= : Graceful shutdown seconds allowed for the worker}
-                                {--daemon : Run worker using queue:work instead of queue:listen}
-                                {--force : Force the worker to run even in maintenance mode}';
+    protected string $signature = '{connection : The name of the queue connection to work}
+                                   {--queue= : The names of the queues to work}
+                                   {--timeout= : Maximum seconds a job can run}
+                                   {--sleep=3 : Number of seconds to sleep when no job is available}
+                                   {--delay= : The number of seconds to delay failed jobs}
+                                   {--tries= : Number of times to attempt a job before logging it failed}
+                                   {--php_version=php : PHP version to use}
+                                   {--environment= : Environment to run the queue worker in}
+                                   {--memory= : The memory limit in megabytes}
+                                   {--directory= : Working directory}
+                                   {--numprocs= : Number of workers to run}
+                                   {--stopwaitsecs= : Graceful shutdown seconds allowed for the worker}
+                                   {--daemon : Run worker using queue:work instead of queue:listen}
+                                   {--force : Force the worker to run even in maintenance mode}';
 
     public function handle(array $commands): array
     {
@@ -49,7 +49,7 @@ class ParseQueueCommands
         }, $commands);
     }
 
-    public function definition(): InputDefinition
+    protected function definition(): InputDefinition
     {
         [, $arguments, $options] = Parser::parse($this->signature);
 

--- a/app/Actions/ParseQueueCommands.php
+++ b/app/Actions/ParseQueueCommands.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Actions;
+
+use App\Traits\Outputifier;
+use Illuminate\Console\Parser;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\StringInput;
+
+class ParseQueueCommands
+{
+    use AsAction,
+        Outputifier;
+
+    private string $signature = '{connection : The name of the queue connection to work}
+                                {--queue= : The names of the queues to work}
+                                {--timeout= : Maximum seconds a job can run}
+                                {--sleep=3 : Number of seconds to sleep when no job is available}
+                                {--delay= : The number of seconds to delay failed jobs}
+                                {--tries= : Number of times to attempt a job before logging it failed}
+                                {--php_version=php : PHP version to use}
+                                {--environment= : Environment to run the queue worker in}
+                                {--memory= : The memory limit in megabytes}
+                                {--directory= : Working directory}
+                                {--numprocs= : Number of workers to run}
+                                {--stopwaitsecs= : Graceful shutdown seconds allowed for the worker}
+                                {--daemon : Run worker using queue:work instead of queue:listen}
+                                {--force : Force the worker to run even in maintenance mode}';
+
+    public function handle(array $commands): array
+    {
+        $definition = $this->definition();
+
+        return array_map(function ($command) use ($definition) {
+            $input = new StringInput($command);
+            $input->bind($definition);
+
+            if (blank($input->getArgument('connection'))) {
+                $this->failCommand("No queue connection was specified for command: {$command}");
+
+                return [];
+            }
+
+            return array_filter([
+                ...$input->getArguments(),
+                ...$input->getOptions(),
+            ], fn ($value) => ! is_null($value));
+        }, $commands);
+    }
+
+    public function definition(): InputDefinition
+    {
+        [, $arguments, $options] = Parser::parse($this->signature);
+
+        $definition = new InputDefinition();
+        $definition->setArguments($arguments);
+        $definition->setOptions($options);
+
+        return $definition;
+    }
+}

--- a/app/Commands/ProvisionCommand.php
+++ b/app/Commands/ProvisionCommand.php
@@ -16,6 +16,7 @@ namespace App\Commands;
 use App\Services\Forge\ForgeService;
 use App\Services\Forge\Pipeline\AnnounceSiteOnSlack;
 use App\Services\Forge\Pipeline\CreateDatabase;
+use App\Services\Forge\Pipeline\CreateQueueWorkers;
 use App\Services\Forge\Pipeline\CreateWebhook;
 use App\Services\Forge\Pipeline\DeploySite;
 use App\Services\Forge\Pipeline\EnableInertiaSupport;
@@ -61,6 +62,7 @@ class ProvisionCommand extends Command
                 CreateWebhook::class,
                 RunOptionalCommands::class,
                 EnsureJobScheduled::class,
+                CreateQueueWorkers::class,
                 PutCommentOnPullRequest::class,
                 AnnounceSiteOnSlack::class,
                 EnableInertiaSupport::class,

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -212,7 +212,7 @@ class ForgeSetting
     /**
      * The queue workers to create on new site installation
      */
-    public string $queueWorkers;
+    public ?string $queueWorkers;
 
     public function __construct()
     {

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -209,6 +209,11 @@ class ForgeSetting
      */
     public ?string $webhookUrl;
 
+    /**
+     * The queue workers to create on new site installation
+     */
+    public string $queueWorkers;
+
     public function __construct()
     {
         $this->init(config('forge'));
@@ -265,6 +270,7 @@ class ForgeSetting
             'slack_channel' => ['exclude_if:slack_announcement_enabled,false', 'required', 'string'],
             'inertia_ssr_enabled' => ['required', 'boolean'],
             'github_create_deploy_key' => ['required', 'boolean'],
+            'queue_workers' => ['nullable', 'string'],
         ])->sometimes('git_provider', 'in:custom', function (Fluent $input) {
             return $input->github_create_deploy_key === true;
         });

--- a/app/Services/Forge/Pipeline/CreateQueueWorkers.php
+++ b/app/Services/Forge/Pipeline/CreateQueueWorkers.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Forge\Pipeline;
+
+use App\Actions\ParseQueueCommands;
+use App\Services\Forge\ForgeService;
+use App\Traits\Outputifier;
+use Closure;
+use Illuminate\Support\Str;
+
+class CreateQueueWorkers
+{
+    use Outputifier;
+
+    public function __invoke(ForgeService $service, Closure $next)
+    {
+        if (! $service->setting->queueWorkers || ! $service->siteNewlyMade) {
+            return $next($service);
+        }
+
+        $workers = ParseQueueCommands::run(
+            str($service->setting->queueWorkers)
+                ->explode("\n")
+                ->map(Str::squish(...))
+                ->filter()
+                ->values()
+                ->all()
+        );
+
+        $this->information('Creating queue workers.');
+
+        foreach ($workers as $worker) {
+            $service->forge->createWorker(
+                serverId: $service->server->id,
+                siteId: $service->site->id,
+                data: $worker
+            );
+        }
+
+        return $next($service);
+    }
+}

--- a/config/forge.php
+++ b/config/forge.php
@@ -108,4 +108,7 @@ return [
 
     // The webhook URL to be added to the Forge site.
     'webhook_url' => env('FORGE_WEBHOOK_URL'),
+
+    // The queue workers to be added to Forge site
+    'queue_workers' => env('FORGE_QUEUE_WORKERS'),
 ];

--- a/tests/Feature/Actions/ParseQueueCommandsTest.php
+++ b/tests/Feature/Actions/ParseQueueCommandsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Actions\ParseQueueCommands;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function Termwind\renderUsing;
+
+it('extracts api parameters from command syntax', function ($actual, $expected) {
+    expect(
+        ParseQueueCommands::run($actual)
+    )
+        ->toBe($expected);
+})
+    ->with([
+        [
+            [
+                'redis',
+                'database --queue=default --daemon',
+                'sqs --force --delay=0',
+            ],
+            [
+                [
+                    'connection' => 'redis',
+                    'sleep' => '3',
+                    'php_version' => 'php',
+                    'daemon' => false,
+                    'force' => false,
+                ],
+                [
+                    'connection' => 'database',
+                    'queue' => 'default',
+                    'sleep' => '3',
+                    'php_version' => 'php',
+                    'daemon' => true,
+                    'force' => false,
+                ],
+                [
+                    'connection' => 'sqs',
+                    'sleep' => '3',
+                    'delay' => '0',
+                    'php_version' => 'php',
+                    'daemon' => false,
+                    'force' => true,
+                ],
+            ],
+        ],
+        [
+            [
+                'redis --queue=high,default --timeout=60 --sleep=10 --delay=2 --tries=3 --php_version=php84 --environment=preview --memory=1024 --directory=/path/to/app --numprocs=8 --stopwaitsecs=60 --daemon --force',
+            ],
+            [
+                [
+                    'connection' => 'redis',
+                    'queue' => 'high,default',
+                    'timeout' => '60',
+                    'sleep' => '10',
+                    'delay' => '2',
+                    'tries' => '3',
+                    'php_version' => 'php84',
+                    'environment' => 'preview',
+                    'memory' => '1024',
+                    'directory' => '/path/to/app',
+                    'numprocs' => '8',
+                    'stopwaitsecs' => '60',
+                    'daemon' => true,
+                    'force' => true,
+                ],
+            ],
+        ],
+    ]);
+
+it('shows failure message if connection is not specified', function () {
+    renderUsing($output = new BufferedOutput());
+
+    ParseQueueCommands::run(['--queue=default']);
+
+    expect($output->fetch())
+        ->toContain('FAIL')
+        ->toContain('No queue connection was specified for command: --queue=default');
+
+    renderUsing(null);
+});


### PR DESCRIPTION
### This PR creates queue workers on forge when provisioning a new site.

You can create a single queue worker by specifying only the queue connection.

```yml
env:
  FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
  FORGE_SERVER: ${{ secrets.FORGE_SERVER_ID }}
  FORGE_QUEUE_WORKERS: redis
```

And you can create multiple workers by using multi-line syntax in your github action.


```yml
env:
  FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
  FORGE_SERVER: ${{ secrets.FORGE_SERVER_ID }}
  FORGE_QUEUE_WORKERS: |
    redis --queue=high,default --daemon
    redis --queue=imports --timeout=300 --stopwaitsecs=320
```

All Forge API parameters can be passed as option for the queue definition.

Documentation: https://forge.laravel.com/api-documentation#create-worker

```bash
{queue-connection-name} --queue=high,default --timeout=60 --sleep=10 --delay=2 --tries=3 --php_version=php84 --environment=preview --memory=1024 --directory=/path/to/app --numprocs=8 --stopwaitsecs=60 --daemon --force
```

--

PS: I will probably make another PR for the daemon feature as we need to use Horizon also.