### PR TITLE
Create daemons on initial site provisioning

### DIFF
--- a/app/Actions/LineBreaksToArray.php
+++ b/app/Actions/LineBreaksToArray.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class LineBreaksToArray
+{
+    use AsAction;
+
+    public function handle(?string $content): ?array
+    {
+        return str($content)
+            ->explode("\n")
+            ->map(Str::squish(...))
+            ->filter()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Actions/ParseDaemonCommands.php
+++ b/app/Actions/ParseDaemonCommands.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Actions;
+
+use App\Services\Syntax\CommandParser;
+use App\Traits\CommandSyntax;
+use App\Traits\CommandSyntaxParser;
+use App\Traits\Outputifier;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class ParseDaemonCommands
+{
+    use AsAction,
+        Outputifier,
+        CommandSyntax;
+
+    protected string $signature = '{command* : The command you want to run}
+                                   {--directory= : Working directory}
+                                   {--user= : User to run the command under}
+                                   {--processes=1 : How many processes to run}
+                                   {--startsecs= : The total number of seconds the program must stay running in order to consider the start successful}
+                                   {--stopwaitsecs=10 : The number of seconds Supervisor will allow for the daemon to gracefully stop before forced termination}
+                                   {--stopsignal=SIGTERM : The signal used to kill the program when a stop is requested}';
+
+    public function handle(array $commands): array
+    {
+        $definition = $this->definition($this->signature);
+
+        return array_map(function (string $command) use ($definition) {
+            $input = $this->input($command, $definition);
+
+            if (blank($input->getArgument('command'))) {
+                $this->failCommand("No command was specified for daemon creation: {$command}");
+
+                return [];
+            }
+
+            return array_filter([
+                'command' => implode(' ', $input->getArgument('command')),
+                ...$input->getOptions(),
+            ], fn ($value) => ! is_null($value));
+        }, $commands);
+    }
+}

--- a/app/Commands/ProvisionCommand.php
+++ b/app/Commands/ProvisionCommand.php
@@ -15,6 +15,7 @@ namespace App\Commands;
 
 use App\Services\Forge\ForgeService;
 use App\Services\Forge\Pipeline\AnnounceSiteOnSlack;
+use App\Services\Forge\Pipeline\CreateDaemons;
 use App\Services\Forge\Pipeline\CreateDatabase;
 use App\Services\Forge\Pipeline\CreateQueueWorkers;
 use App\Services\Forge\Pipeline\CreateWebhook;
@@ -62,6 +63,7 @@ class ProvisionCommand extends Command
                 CreateWebhook::class,
                 RunOptionalCommands::class,
                 EnsureJobScheduled::class,
+                CreateDaemons::class,
                 CreateQueueWorkers::class,
                 PutCommentOnPullRequest::class,
                 AnnounceSiteOnSlack::class,

--- a/app/Commands/TearDownCommand.php
+++ b/app/Commands/TearDownCommand.php
@@ -17,6 +17,7 @@ use App\Services\Forge\ForgeService;
 use App\Services\Forge\Pipeline\DestroySite;
 use App\Services\Forge\Pipeline\FindServer;
 use App\Services\Forge\Pipeline\FindSiteOrFail;
+use App\Services\Forge\Pipeline\RemoveDaemons;
 use App\Services\Forge\Pipeline\RemoveDatabaseUser;
 use App\Services\Forge\Pipeline\RemoveExistingDeployKey;
 use App\Services\Forge\Pipeline\RemoveInertiaSupport;
@@ -43,6 +44,7 @@ class TearDownCommand extends Command
                 RunOptionalCommands::class,
                 RemoveDatabaseUser::class,
                 RemoveExistingDeployKey::class,
+                RemoveDaemons::class,
                 DestroySite::class,
             ])
             ->then(fn () => $this->success('Environment teardown successful! All provisioned resources have been removed.'));

--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -156,6 +156,9 @@ class ForgeService
 
     public function siteDirectory(): string
     {
-        return sprintf('/home/%s/%s', $this->site->username, $this->site->name);
+        return Str::chopEnd(
+            subject: $this->site->attributes['web_directory'],
+            needle: $this->site->directory // usually only contains /public
+        );
     }
 }

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -214,6 +214,11 @@ class ForgeSetting
      */
     public ?string $queueWorkers;
 
+    /**
+     * The daemons to create on new site installation
+     */
+    public ?string $daemons;
+
     public function __construct()
     {
         $this->init(config('forge'));
@@ -271,6 +276,7 @@ class ForgeSetting
             'inertia_ssr_enabled' => ['required', 'boolean'],
             'github_create_deploy_key' => ['required', 'boolean'],
             'queue_workers' => ['nullable', 'string'],
+            'daemons' => ['nullable', 'string'],
         ])->sometimes('git_provider', 'in:custom', function (Fluent $input) {
             return $input->github_create_deploy_key === true;
         });

--- a/app/Services/Forge/Pipeline/CreateDaemons.php
+++ b/app/Services/Forge/Pipeline/CreateDaemons.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Forge\Pipeline;
+
+use App\Actions\LineBreaksToArray;
+use App\Actions\ParseDaemonCommands;
+use App\Services\Forge\ForgeService;
+use App\Traits\Outputifier;
+use Closure;
+
+class CreateDaemons
+{
+    use Outputifier;
+
+    public function __invoke(ForgeService $service, Closure $next)
+    {
+        if (! $service->setting->daemons || ! $service->siteNewlyMade) {
+            return $next($service);
+        }
+
+        $daemons = ParseDaemonCommands::run(
+            LineBreaksToArray::run($service->setting->daemons),
+        );
+
+        $this->information('Creating daemons.');
+
+        foreach ($daemons as $daemon) {
+            $service->forge->createDaemon(
+                serverId: $service->server->id,
+                data: array_merge(
+                    [
+                        // Defaults a daemon to run under the same user and directory as the current site.
+                        'user' => $service->site->username,
+                        'directory' => $service->siteDirectory(),
+                    ],
+                    $daemon
+                )
+            );
+        }
+
+        return $next($service);
+    }
+}

--- a/app/Services/Forge/Pipeline/CreateQueueWorkers.php
+++ b/app/Services/Forge/Pipeline/CreateQueueWorkers.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\Forge\Pipeline;
 
+use App\Actions\LineBreaksToArray;
 use App\Actions\ParseQueueCommands;
 use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
 use Closure;
-use Illuminate\Support\Str;
 
 class CreateQueueWorkers
 {
@@ -21,12 +21,7 @@ class CreateQueueWorkers
         }
 
         $workers = ParseQueueCommands::run(
-            str($service->setting->queueWorkers)
-                ->explode("\n")
-                ->map(Str::squish(...))
-                ->filter()
-                ->values()
-                ->all()
+            LineBreaksToArray::run($service->setting->queueWorkers),
         );
 
         $this->information('Creating queue workers.');

--- a/app/Services/Forge/Pipeline/RemoveDaemons.php
+++ b/app/Services/Forge/Pipeline/RemoveDaemons.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Forge\Pipeline;
+
+use App\Actions\LineBreaksToArray;
+use App\Actions\ParseDaemonCommands;
+use App\Services\Forge\ForgeService;
+use App\Services\Forge\ForgeSetting;
+use App\Traits\Outputifier;
+use Closure;
+use Illuminate\Support\Str;
+use Laravel\Forge\Resources\Daemon;
+
+class RemoveDaemons
+{
+    use Outputifier;
+
+    public function __invoke(ForgeService $service, Closure $next)
+    {
+        $daemons = $service->forge->daemons($service->server->id);
+
+        $this->information('Deleting daemons');
+
+        foreach ($daemons as $daemon) {
+            // If the daemon is running under the same user as the site in user isolation mode.
+            if ($service->setting->siteIsolationRequired && $daemon->user === $service->site->username) {
+                $service->forge->deleteDaemon($service->server->id, $daemon->id);
+                $this->information("--> Deleted daemon under user: {$daemon->command}");
+
+                continue;
+            }
+
+            // If the daemon is running from the same directory as the site.
+            if (Str::contains(haystack: $daemon->directory, needles: $service->siteDirectory())) {
+                $service->forge->deleteDaemon($service->server->id, $daemon->id);
+                $this->information("--> Deleted daemon under directory: {$daemon->command}");
+
+                continue;
+            }
+
+            // If a daemon can be detected as being one that was configured by us.
+            if ($this->daemonWasAddedForThisSite($daemon, $service->setting)) {
+                $service->forge->deleteDaemon($service->server->id, $daemon->id);
+                $this->information("--> Deleted daemon created with site: {$daemon->command}");
+            }
+        }
+
+        return $next($service);
+    }
+
+    protected function daemonWasAddedForThisSite(Daemon $daemon, ForgeSetting $setting): bool
+    {
+        if (empty($setting->daemons)) {
+            return false;
+        }
+
+        $configuredDaemons = ParseDaemonCommands::run(
+            LineBreaksToArray::run($setting->daemons),
+        );
+
+        return collect($configuredDaemons)->contains(
+            fn (array $configuredDaemon) => $configuredDaemon['command'] === $daemon->command
+                && $configuredDaemon['user'] === $daemon->user
+                && $configuredDaemon['directory'] === $daemon->directory
+        );
+    }
+}

--- a/app/Traits/CommandSyntax.php
+++ b/app/Traits/CommandSyntax.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Console\Parser;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\StringInput;
+
+trait CommandSyntax
+{
+    protected function input(string $command, InputDefinition $definition): StringInput
+    {
+        $input = new StringInput($command);
+        $input->bind($definition);
+
+        return $input;
+    }
+
+    protected function definition(string $signature): InputDefinition
+    {
+        [, $arguments, $options] = Parser::parse($signature);
+
+        $definition = new InputDefinition();
+        $definition->setArguments($arguments);
+        $definition->setOptions($options);
+
+        return $definition;
+    }
+}

--- a/config/forge.php
+++ b/config/forge.php
@@ -111,4 +111,7 @@ return [
 
     // The queue workers to be added to Forge site
     'queue_workers' => env('FORGE_QUEUE_WORKERS'),
+
+    // The daemons to create on a Forge server
+    'daemons' => env('FORGE_DAEMONS'),
 ];

--- a/tests/Feature/Actions/LineBreaksToArrayTest.php
+++ b/tests/Feature/Actions/LineBreaksToArrayTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Actions\LineBreaksToArray;
+use App\Actions\TextToArray;
+
+it('converts string into array items by line breaks', function ($actual, $expected) {
+    expect(
+        LineBreaksToArray::run($actual)
+    )
+        ->toBe($expected);
+})
+    ->with([
+        [
+            "First line\nSecond line",
+            [
+                'First line',
+                'Second line',
+            ],
+        ],
+        [
+            "\nFirst line\n\nSecond line\n",
+            [
+                'First line',
+                'Second line',
+            ],
+        ],
+        [
+            " \nOnly 2 lines\n3rd line has invisible space\n‎ ",
+            [
+                'Only 2 lines',
+                '3rd line has invisible space',
+            ],
+        ],
+        [
+            null,
+            [],
+        ],
+        [
+            '',
+            [],
+        ],
+    ]);

--- a/tests/Feature/Actions/ParseDaemonCommandsTest.php
+++ b/tests/Feature/Actions/ParseDaemonCommandsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Actions\ParseDaemonCommands;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function Termwind\renderUsing;
+
+it('extracts api parameters from command syntax', function ($actual, $expected) {
+    expect(
+        ParseDaemonCommands::run($actual)
+    )
+        ->toBe($expected);
+})
+    ->with([
+        [
+            [
+                'php artisan horizon',
+                'custom-script --directory=/usr/local/bin',
+            ],
+            [
+                [
+                    'command' => 'php artisan horizon',
+                    'processes' => '1',
+                    'stopwaitsecs' => '10',
+                    'stopsignal' => 'SIGTERM',
+                ],
+                [
+                    'command' => 'custom-script',
+                    'directory' => '/usr/local/bin',
+                    'processes' => '1',
+                    'stopwaitsecs' => '10',
+                    'stopsignal' => 'SIGTERM',
+                ],
+            ],
+        ],
+        [
+            [
+                "'script-with-parameters -e --foo=bar' --directory=/path/to/daemon --user=root --processes=2 --startsecs=10 --stopwaitsecs=30 --stopsignal=SIGKILL",
+            ],
+            [
+                [
+                    'command' => 'script-with-parameters -e --foo=bar',
+                    'directory' => '/path/to/daemon',
+                    'user' => 'root',
+                    'processes' => '2',
+                    'startsecs' => '10',
+                    'stopwaitsecs' => '30',
+                    'stopsignal' => 'SIGKILL',
+                ],
+            ],
+        ],
+    ]);
+
+it('shows failure message if command is not specified', function () {
+    renderUsing($output = new BufferedOutput());
+
+    ParseDaemonCommands::run(['--user=anthony']);
+
+    expect($output->fetch())
+        ->toContain('FAIL')
+        ->toContain('No command was specified for daemon creation: --user=anthony');
+
+    renderUsing(null);
+});


### PR DESCRIPTION
### This PR allows creating daemons on forge when provisioning a new site.

You can create a single or multiple daemons the same way as queue workers. The user and directory is set to the same ones used on the site, a reasonable default I think.

```yml
env:
  FORGE_DAEMONS: php artisan horizon
```

or

```yml
env:
  FORGE_DAEMONS: |
    php artisan horizon
    php artisan pulse:check
    custom.sh --directory=/path/to/script --user=forge --processes=1 --startsecs=10 --stopwaitsecs=60 --stopsignal=SIGTERM
```

If the command you need to run has arguments of its own, you can single or double quote the entire command.

```yml
env:
  FORGE_DAEMONS: "something-to-run --argument=value" --directory=/path/to/script --user=forge
```

---

### Handling of teardown process.

When in user isolation mode, daemon removal happens by deleting all daemons that are running as the user used for the site. 

In all cases, daemons are deleted if their directory falls within the site currently being teardown-ed.

After all that, any remaining daemons are deleted based on the env variable set by the user. So it is recommended to add the same env value for `FORGE_DAEMONS` for teardown workflow as well. Would ask you to review the code for teardown carefully. Thanks.

---

###  And finally some concerns

The inertia pipeline steps seem redundant for the most part and can simply be replaced with `php artisan inertia:start-ssr` in the `FORGE_DAEMONS`. Additionally, it adds `inertia:stop-ssr` to the deployment script, which seems out of scope to do automatically. The user still needs to write their deployment script anyway, and they should add the daemon-killing command to their script, as suggested by the documentation for those libraries.

That being said, I have not made any changes to inertia as that would be a breaking change. 

I will be submitting another PR to fix handling of user isolation in scheduler job and inertia daemon creation. Since at the moment it's hard coded to `forge`.

Appolgies for the wall of text 😞 

