### PR TITLE
Fix username on scheduler and ineria daemon when using isolated user feature.

### DIFF
--- a/app/Services/Forge/Pipeline/EnableInertiaSupport.php
+++ b/app/Services/Forge/Pipeline/EnableInertiaSupport.php
@@ -44,7 +44,7 @@ class EnableInertiaSupport
 
         $service->forge->createDaemon($service->server->id, [
             'command' => 'php artisan inertia:start-ssr',
-            'user' => 'forge',
+            'user' => $service->site->username,
             'directory' => $service->siteDirectory(),
         ]);
     }

--- a/app/Services/Forge/Pipeline/EnsureJobScheduled.php
+++ b/app/Services/Forge/Pipeline/EnsureJobScheduled.php
@@ -46,7 +46,7 @@ class EnsureJobScheduled
         $service->forge->createJob($service->server->id, [
             'command' => $command,
             'frequency' => 'minutely',
-            'user' => 'forge',
+            'user' => $service->site->username,
         ]);
     }
 


### PR DESCRIPTION
This fixes the username used on scheduler job creation and inertia daemon by getting the username off the site API record instead of hardcoding it.