### PR TITLE
Allow configuring the site directory

### DIFF
--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -80,6 +80,11 @@ class ForgeSetting
     public ?string $phpVersion = null;
 
     /**
+     * The directory to deploy the site to.
+     */
+    public ?string $directory = null;
+
+    /**
      * Pattern for subdomains.
      */
     public ?string $subdomainPattern = null;
@@ -269,6 +274,7 @@ class ForgeSetting
             'branch' => ['required', new BranchNameRegex],
             'project_type' => ['string'],
             'php_version' => ['nullable', 'string'],
+            'directory' => ['nullable', 'string'],
             'subdomain_pattern' => ['nullable', 'string'],
             'command' => ['nullable', 'string'],
             'nginx_template' => ['nullable', 'int'],

--- a/app/Services/Forge/Pipeline/OrCreateNewSite.php
+++ b/app/Services/Forge/Pipeline/OrCreateNewSite.php
@@ -47,7 +47,7 @@ class OrCreateNewSite
             'www_redirect_type' => 'none',
             'allow_wildcard_subdomains' => false,
             'php_version' => $service->setting->phpVersion,
-            'web_directory' => '/public',
+            'web_directory' => $service->setting->directory,
             'source_control_provider' => $service->setting->gitProvider,
             'repository' => $service->setting->gitProvider !== 'custom' ? $service->setting->repository : $service->setting->repositoryUrl,
             'branch' => $service->setting->branch,

--- a/config/forge.php
+++ b/config/forge.php
@@ -52,6 +52,9 @@ return [
     // Type of the project (default: 'php').
     'project_type' => env('FORGE_PROJECT_TYPE', 'php'),
 
+    // The directory to deploy the site to (default: '/public').
+    'directory' => env('FORGE_DIRECTORY', '/public'),
+
     // Flag indicating if site isolation is needed (default: false).
     'site_isolation_required' => env('FORGE_SITE_ISOLATION', false),
 

--- a/tests/Feature/OrCreateSiteTest.php
+++ b/tests/Feature/OrCreateSiteTest.php
@@ -11,6 +11,7 @@ test('it fails on incorrect payload', function ($site, $expectedErrors) {
     $setting->server = '111111';
     $setting->projectType = 'php';
     $setting->phpVersion = 'php82';
+    $setting->directory = '/public';
     $setting->gitProvider = 'github';
     $setting->repository = 'acme/example';
     $setting->repositoryUrl = null;

--- a/tests/Feature/OrCreateSiteTest.php
+++ b/tests/Feature/OrCreateSiteTest.php
@@ -1,26 +1,13 @@
 <?php
 
+use App\Services\Forge\Api\Exceptions\ForgeValidationException as ValidationException;
+use App\Services\Forge\Data\ForgeSiteData;
 use App\Services\Forge\ForgeService;
 use App\Services\Forge\ForgeSetting;
-use App\Services\Forge\Api\Exceptions\ForgeValidationException as ValidationException;
 use App\Services\Forge\Pipeline\OrCreateNewSite;
 
 test('it fails on incorrect payload', function ($site, $expectedErrors) {
-    $service = mock(ForgeService::class);
-    $setting = Mockery::mock(ForgeSetting::class);
-    $setting->server = '111111';
-    $setting->projectType = 'php';
-    $setting->phpVersion = 'php82';
-    $setting->directory = '/public';
-    $setting->gitProvider = 'github';
-    $setting->repository = 'acme/example';
-    $setting->repositoryUrl = null;
-    $setting->branch = 'main';
-    $setting->quickDeploy = false;
-    $setting->githubCreateDeployKey = false;
-    $setting->nginxTemplate = null;
-    $setting->siteIsolationRequired = false;
-    $service->setting = $setting;
+    $service = mockForgeServiceForSiteCreation(directory: '/public');
 
     $service->shouldReceive('getFormattedDomainName')
         ->once()
@@ -28,20 +15,7 @@ test('it fails on incorrect payload', function ($site, $expectedErrors) {
 
     $service->shouldReceive('createSite')
         ->once()
-        ->with('111111', [
-            'type' => 'php',
-            'domain_mode' => 'custom',
-            'name' => $site['name'],
-            'www_redirect_type' => 'none',
-            'allow_wildcard_subdomains' => false,
-            'php_version' => 'php82',
-            'web_directory' => '/public',
-            'source_control_provider' => 'github',
-            'repository' => 'acme/example',
-            'branch' => 'main',
-            'push_to_deploy' => false,
-            'generate_deploy_key' => false,
-        ])
+        ->with('111111', expectedSitePayload($site['name'], '/public'))
         ->andThrow(new ValidationException(
             message: implode(PHP_EOL, collect($expectedErrors)->flatten()->all()),
             statusCode: 422,
@@ -57,3 +31,115 @@ test('it fails on incorrect payload', function ($site, $expectedErrors) {
         'expected_errors' => [['First Error', 'Second Error']],
     ])
     ->throws(ValidationException::class);
+
+test('it uses the configured directory as web_directory', function () {
+    $service = mockForgeServiceForSiteCreation(directory: '/playground/public');
+    $createdSite = fakeCreatedSite();
+
+    $service->shouldReceive('getFormattedDomainName')
+        ->once()
+        ->andReturn('preview.harbor.test');
+
+    $service->shouldReceive('createSite')
+        ->once()
+        ->with('111111', expectedSitePayload('preview.harbor.test', '/playground/public'))
+        ->andReturn($createdSite);
+
+    $service->shouldReceive('setSite')
+        ->once()
+        ->with($createdSite);
+
+    $service->shouldReceive('getFormattedAliases')
+        ->once()
+        ->andReturn([]);
+
+    expect(
+        app(OrCreateNewSite::class)($service, fn ($service) => $service)
+    )
+        ->toBe($service);
+});
+
+test('it omits web_directory when directory is null', function () {
+    $service = mockForgeServiceForSiteCreation(directory: null);
+    $createdSite = fakeCreatedSite();
+
+    $service->shouldReceive('getFormattedDomainName')
+        ->once()
+        ->andReturn('preview.harbor.test');
+
+    $payload = expectedSitePayload('preview.harbor.test', '/public');
+    unset($payload['web_directory']);
+
+    $service->shouldReceive('createSite')
+        ->once()
+        ->with('111111', $payload)
+        ->andReturn($createdSite);
+
+    $service->shouldReceive('setSite')
+        ->once()
+        ->with($createdSite);
+
+    $service->shouldReceive('getFormattedAliases')
+        ->once()
+        ->andReturn([]);
+
+    expect(
+        app(OrCreateNewSite::class)($service, fn ($service) => $service)
+    )
+        ->toBe($service);
+});
+
+function mockForgeServiceForSiteCreation(?string $directory): ForgeService
+{
+    $service = mock(ForgeService::class);
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->server = '111111';
+    $setting->projectType = 'php';
+    $setting->phpVersion = 'php82';
+    $setting->directory = $directory;
+    $setting->gitProvider = 'github';
+    $setting->repository = 'acme/example';
+    $setting->repositoryUrl = null;
+    $setting->branch = 'main';
+    $setting->quickDeploy = false;
+    $setting->githubCreateDeployKey = false;
+    $setting->nginxTemplate = null;
+    $setting->siteIsolationRequired = false;
+    $service->setting = $setting;
+    $service->site = null;
+
+    return $service;
+}
+
+function expectedSitePayload(string $name, string $webDirectory): array
+{
+    return [
+        'type' => 'php',
+        'domain_mode' => 'custom',
+        'name' => $name,
+        'www_redirect_type' => 'none',
+        'allow_wildcard_subdomains' => false,
+        'php_version' => 'php82',
+        'web_directory' => $webDirectory,
+        'source_control_provider' => 'github',
+        'repository' => 'acme/example',
+        'branch' => 'main',
+        'push_to_deploy' => false,
+        'generate_deploy_key' => false,
+    ];
+}
+
+function fakeCreatedSite(): ForgeSiteData
+{
+    return new ForgeSiteData(
+        id: 1,
+        name: 'preview.harbor.test',
+        status: null,
+        username: 'forge',
+        repository: null,
+        webDirectory: null,
+        rootDirectory: null,
+        directory: null,
+        deploymentUrl: null,
+    );
+}


### PR DESCRIPTION
Currently the web directory is set to `/public`, with no option to change this. This adds a new environment value that allows overwriting this option.

For example, we have a Laravel package (so not an app), but within it we have a playground. This playground is an app to visually test the package. Thus we need to update the directory to `/playground/public`, which we currently do with an artisan command in the deploy script.

I have yet to test this, but I think this value should be used for the document_root, not where the project itself is located. We currently use this endpoint: https://forge.laravel.com/api-documentation#update-site. And that works as intended, so I think the new site creation should also work.

I can set this PR to draft until I've had a chance to test/verify, if you prefer that :)