### PR TITLE
Allow configuring aliases

### DIFF
--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -81,6 +81,15 @@ class ForgeService
         );
     }
 
+    public function getFormattedAliases(): array
+    {
+        $subdomain = $this->setting->subdomainName ?? $this->getFormattedBranchName();
+
+        return collect(explode(',', $this->setting->aliases) ?? [])
+            ->map(fn($alias) => GenerateDomainName::run(trim($alias), $subdomain))
+            ->toArray();
+    }
+
     public function getSiteIsolationUsername(): string
     {
         if (!empty($this->setting->siteIsolationUsername)) {
@@ -151,7 +160,7 @@ class ForgeService
             return $this->setting->environmentUrl;
         }
 
-        return ($this->setting->sslRequired ? 'https://' : 'http://').$this->site->name;
+        return ($this->setting->sslRequired ? 'https://' : 'http://') . $this->site->name;
     }
 
     public function siteDirectory(): string

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -42,7 +42,7 @@ class ForgeSetting
     /**
      * Website's aliases.
      */
-    public string $aliases;
+    public ?string $aliases;
 
     /**
      * Git service provider (e.g., github, gitlab).

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -40,6 +40,11 @@ class ForgeSetting
     public string $domain;
 
     /**
+     * Website's aliases.
+     */
+    public string $aliases;
+
+    /**
      * Git service provider (e.g., github, gitlab).
      */
     public string $gitProvider;
@@ -244,6 +249,7 @@ class ForgeSetting
             'token' => ['required'],
             'server' => ['required'],
             'domain' => ['required'],
+            'aliases' => ['nullable', 'string'],
             'git_provider' => ['required'],
             'repository' => ['required'],
             'repository_url' => ['nullable', 'string', 'required_if:git_provider,custom'],

--- a/app/Services/Forge/Pipeline/OrCreateNewSite.php
+++ b/app/Services/Forge/Pipeline/OrCreateNewSite.php
@@ -39,7 +39,6 @@ class OrCreateNewSite
     {
         $data = [
             'domain' => $service->getFormattedDomainName(),
-            'aliases' => $service->getFormattedAliases(),
             'project_type' => $service->setting->projectType,
             'php_version' => $service->setting->phpVersion,
             'directory' => '/public',
@@ -56,6 +55,10 @@ class OrCreateNewSite
 
             $data['isolated'] = true;
             $data['username'] = $service->getSiteIsolationUsername();
+        }
+
+        if ($aliases = $service->getFormattedAliases()) {
+            $data['aliases'] = $aliases;
         }
 
         return $data;

--- a/app/Services/Forge/Pipeline/OrCreateNewSite.php
+++ b/app/Services/Forge/Pipeline/OrCreateNewSite.php
@@ -39,6 +39,7 @@ class OrCreateNewSite
     {
         $data = [
             'domain' => $service->getFormattedDomainName(),
+            'aliases' => $service->getFormattedAliases(),
             'project_type' => $service->setting->projectType,
             'php_version' => $service->setting->phpVersion,
             'directory' => '/public',

--- a/config/forge.php
+++ b/config/forge.php
@@ -10,6 +10,9 @@ return [
     // Website's domain name.
     'domain' => env('FORGE_DOMAIN'),
 
+    // Website's aliases
+    'aliases' => env('FORGE_ALIASES'),
+
     // Git service provider (default: 'github').
     'git_provider' => env('FORGE_GIT_PROVIDER', 'github'),
 

--- a/tests/Unit/Services/Forge/ForgeServiceTest.php
+++ b/tests/Unit/Services/Forge/ForgeServiceTest.php
@@ -47,3 +47,21 @@ test('it gets the site link using HTTP when SSL is not required', function () {
 
     expect($service->getSiteLink())->toBe('http://foo.bar');
 });
+
+test('it gets the site aliases from settings', function () {
+
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->subdomainName = 'test-domain';
+    $setting->aliases = 'alias1.com, alias2.de, alias3.se';
+    $setting->timeoutSeconds = 0;
+
+    $service = new ForgeService($setting,  new Forge);
+
+    expect($service->getFormattedAliases())
+        ->toBeArray()
+        ->toBe([
+            'test-domain.alias1.com',
+            'test-domain.alias2.de',
+            'test-domain.alias3.se',
+        ]);
+});

--- a/tests/Unit/Services/Forge/ForgeServiceTest.php
+++ b/tests/Unit/Services/Forge/ForgeServiceTest.php
@@ -65,3 +65,17 @@ test('it gets the site aliases from settings', function () {
             'test-domain.alias3.se',
         ]);
 });
+
+test('it handles empty aliases string correctly', function () {
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->subdomainName = 'test-domain';
+    $setting->aliases = '';
+    $setting->timeoutSeconds = 0;
+
+    $service = new ForgeService($setting, new Forge);
+
+    expect($service->getFormattedAliases())
+        ->toBeArray()
+        ->toHaveCount(1)
+        ->toBe(['test-domain.']);
+});


### PR DESCRIPTION
We are missing the opportunity to create aliases for our site on forge.

We added a unit test in ForgeServeTest for checking that aliases is working as intended.