### PR TITLE
Fix #134: Add option to force delete and recreate existing database

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ hashFiles('**/composer.lock') }}

--- a/app/Commands/TearDownCommand.php
+++ b/app/Commands/TearDownCommand.php
@@ -43,7 +43,7 @@ class TearDownCommand extends Command
                 FindSiteOrFail::class,
                 RemoveInertiaSupport::class,
                 RunOptionalCommands::class,
-                RemoveDatabaseUser::class,
+//                RemoveDatabaseUser::class,
                 RemoveExistingDeployKey::class,
                 RemoveDaemons::class,
                 RemoveTaskScheduler::class,

--- a/app/Commands/TearDownCommand.php
+++ b/app/Commands/TearDownCommand.php
@@ -43,7 +43,7 @@ class TearDownCommand extends Command
                 FindSiteOrFail::class,
                 RemoveInertiaSupport::class,
                 RunOptionalCommands::class,
-//                RemoveDatabaseUser::class,
+                RemoveDatabaseUser::class,
                 RemoveExistingDeployKey::class,
                 RemoveDaemons::class,
                 RemoveTaskScheduler::class,

--- a/app/Services/Forge/Actions/RecreateDatabase.php
+++ b/app/Services/Forge/Actions/RecreateDatabase.php
@@ -22,7 +22,7 @@ class RecreateDatabase
 
     /**
      * Handle database recreation and creation process
-     * 
+     *
      * @param ForgeService $service The forge service
      * @param string $dbName The database name
      * @param string $dbPassword Password for database creation
@@ -43,9 +43,9 @@ class RecreateDatabase
             return true; // Still need to update env vars even if we don't create DB
         }
 
-        $this->information('Force deleting existing matched database and user if found.');
-
         if (isset($databaseId)) {
+            $this->information('Force deleting existing matched database.');
+
             $service->forge->deleteDatabase($service->server->id, $databaseId);
             $this->information('---> Existing database deleted: ' . $dbName);
         }
@@ -61,7 +61,7 @@ class RecreateDatabase
             $this->information('---> Waiting for the database deletion to complete...');
             $this->waitForDatabaseDeletion();
         }
-        
+
         // Create the database with the provided password
         $this->information('Creating database.');
         $this->createDatabase($service, $dbName, $dbPassword);
@@ -76,7 +76,7 @@ class RecreateDatabase
     {
         sleep(6);
     }
-    
+
     /**
      * Create a new database on the server
      */
@@ -87,7 +87,7 @@ class RecreateDatabase
             'user' => $dbName,
             'password' => $dbPassword,
         ]);
-        
+
         $this->information('Database created: ' . $dbName);
     }
 }

--- a/app/Services/Forge/Actions/RecreateDatabase.php
+++ b/app/Services/Forge/Actions/RecreateDatabase.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Harbor.
+ *
+ * (c) Mehran Rasulian <mehran.rasulian@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace App\Services\Forge\Actions;
+
+use App\Services\Forge\ForgeService;
+use App\Traits\Outputifier;
+
+class RecreateDatabase
+{
+    use Outputifier;
+
+    /**
+     * Handle database recreation and creation process
+     * 
+     * @param ForgeService $service The forge service
+     * @param string $dbName The database name
+     * @param string $dbPassword Password for database creation
+     * @return bool True if database needs to be updated in the env file
+     */
+    public function handle(ForgeService $service, string $dbName, string $dbPassword): bool
+    {
+        $databaseId = null;
+        foreach ($service->forge->databases($service->server->id) as $database) {
+            if (isset($database->name) && $database->name === $dbName) {
+                $databaseId = $database->id;
+            }
+        }
+
+        // If the setting is not enabled, we skip the deletion of existing databases.
+        if (isset($databaseId) && !$service->setting->forceDeleteOldDatabase) {
+            $this->warning('It seems there is an existing database with the same name. Skipping database creation. Ensure to update the database password in the .env file manually.');
+            return true; // Still need to update env vars even if we don't create DB
+        }
+
+        $this->information('Force deleting existing matched database and user if found.');
+
+        if (isset($databaseId)) {
+            $service->forge->deleteDatabase($service->server->id, $databaseId);
+            $this->information('---> Existing database deleted: ' . $dbName);
+        }
+
+        foreach ($service->forge->databaseUsers($service->server->id) as $user) {
+            if (isset($user->name) && $user->name === $dbName) {
+                $service->forge->deleteDatabaseUser($service->server->id, $user->id);
+                $this->information('---> Existing database user found and deleted: ' . $dbName);
+            }
+        }
+
+        if (isset($databaseId)) {
+            $this->information('---> Waiting for the database deletion to complete...');
+            $this->waitForDatabaseDeletion();
+        }
+        
+        // Create the database with the provided password
+        $this->information('Creating database.');
+        $this->createDatabase($service, $dbName, $dbPassword);
+
+        return true;
+    }
+
+    /**
+     * Wait for database deletion to complete
+     */
+    protected function waitForDatabaseDeletion(): void
+    {
+        sleep(6);
+    }
+    
+    /**
+     * Create a new database on the server
+     */
+    public function createDatabase(ForgeService $service, string $dbName, string $dbPassword): void
+    {
+        $service->forge->createDatabase($service->server->id, [
+            'name' => $dbName,
+            'user' => $dbName,
+            'password' => $dbPassword,
+        ]);
+        
+        $this->information('Database created: ' . $dbName);
+    }
+}

--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -130,6 +130,11 @@ class ForgeSetting
     public bool $dbCreationRequired;
 
     /**
+     * Flag indicating if Harbor should remove the existing old database.
+     */
+    public bool $forceDeleteOldDatabase;
+
+    /**
      * The name of the database to be created
      */
     public ?string $dbName;
@@ -258,6 +263,7 @@ class ForgeSetting
             'site_isolation_username' => ['nullable', 'string'],
             'job_scheduler_required' => ['boolean'],
             'db_creation_required' => ['boolean'],
+            'force_delete_old_database' => ['boolean'],
             'db_name' => ['nullable', 'string'],
             'auto_source_required' => ['boolean'],
             'ssl_required' => ['boolean'],

--- a/app/Services/Forge/Pipeline/CreateDatabase.php
+++ b/app/Services/Forge/Pipeline/CreateDatabase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Services\Forge\Pipeline;
 
+use App\Services\Forge\Actions\RecreateDatabase;
 use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
 use Closure;
@@ -21,7 +22,14 @@ use Illuminate\Support\Str;
 class CreateDatabase
 {
     use Outputifier;
+    
+    private RecreateDatabase $recreateDatabase;
 
+    public function __construct(RecreateDatabase $recreateDatabase = null)
+    {
+        $this->recreateDatabase = $recreateDatabase ?? new RecreateDatabase();
+    }
+    
     public function __invoke(ForgeService $service, Closure $next)
     {
         if (! $service->setting->dbCreationRequired || ! $service->siteNewlyMade) {
@@ -30,12 +38,9 @@ class CreateDatabase
 
         $dbName = $service->getFormattedDatabaseName();
         $dbPassword = Str::random(16);
-
-        if (! $this->databaseExists($service, $dbName)) {
-            $this->information('Creating database.');
-
-            $this->createDatabase($service, $dbName, $dbPassword);
-        }
+        
+        // Handle DB recreation and creation in one call
+        $this->recreateDatabase->handle($service, $dbName, $dbPassword);
 
         $service->setDatabase([
             'DB_DATABASE' => $dbName,
@@ -46,23 +51,7 @@ class CreateDatabase
         return $next($service);
     }
 
-    protected function databaseExists(ForgeService $service, string $dbName): bool
-    {
-        foreach ($service->forge->databases($service->server->id) as $database) {
-            if ($database->name === $dbName) {
-                return true;
-            }
-        }
 
-        return false;
-    }
 
-    protected function createDatabase(ForgeService $service, string $dbName, string $dbPassword): void
-    {
-        $service->forge->createDatabase($service->server->id, [
-            'name' => $dbName,
-            'user' => $dbName,
-            'password' => $dbPassword,
-        ]);
-    }
+
 }

--- a/config/forge.php
+++ b/config/forge.php
@@ -61,6 +61,9 @@ return [
     // Flag indicating if a database should be created (default: false).
     'db_creation_required' => env('FORGE_DB_CREATION_REQUIRED', false),
 
+    // Flag indicating if Harbor should remove the existing old database (default: false).
+    'force_delete_old_database' => env('FORCE_DELETE_OLD_DATABASE', false),
+
     // Flag to enable Quick Deploy (default: true).
     'quick_deploy' => env('FORGE_QUICK_DEPLOY', false),
 

--- a/tests/Unit/Services/Forge/Actions/RecreateDatabaseTest.php
+++ b/tests/Unit/Services/Forge/Actions/RecreateDatabaseTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use App\Services\Forge\Actions\RecreateDatabase;
+use App\Services\Forge\ForgeSetting;
+use App\Services\Forge\ForgeService;
+use Laravel\Forge\Forge;
+use Laravel\Forge\Resources\Server;
+
+beforeEach(function () {
+    // Setup action and common variables
+    $this->action = new RecreateDatabase();
+    $this->serverId = '12345';
+    $this->dbName = 'test_db';
+    $this->dbPassword = 'test_password';
+    
+    // Create mocks that will be used by all tests
+    $this->forgeMock = Mockery::mock(Forge::class);
+    $this->settingMock = Mockery::mock(ForgeSetting::class);
+    $this->server = new Server(['id' => $this->serverId]);
+    
+    // Setup base service mock that can be customized per test
+    $this->service = Mockery::mock(ForgeService::class);
+    $this->service->forge = $this->forgeMock;
+    $this->service->server = $this->server;
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+it('skips recreation when database exists and force delete disabled', function () {
+    // Configure setting for this specific test
+    $this->settingMock->forceDeleteOldDatabase = false;
+    $this->service->setting = $this->settingMock;
+
+    // Mock database exists
+    $this->forgeMock->shouldReceive('databases')
+        ->once()
+        ->with($this->serverId)
+        ->andReturn([
+            (object) ['name' => $this->dbName, 'id' => 99],
+        ]);
+
+    // Database should not be deleted
+    $this->forgeMock->shouldNotReceive('deleteDatabase');
+    $this->forgeMock->shouldNotReceive('deleteDatabaseUser');
+
+    // Database should not be created when skipping recreation
+    $this->forgeMock->shouldNotReceive('createDatabase');
+
+    // Act
+    $result = $this->action->handle($this->service, $this->dbName, $this->dbPassword);
+
+    // Assert
+    expect($result)->toBeTrue(); // Should return true to indicate env vars need updating
+});
+
+it('recreates database when exists and force delete enabled', function () {
+    // Configure setting for this specific test
+    $this->settingMock->forceDeleteOldDatabase = true;
+    $this->service->setting = $this->settingMock;
+
+    // Mock existing database
+    $dbId = 99;
+    $userId = 88;
+
+    $this->forgeMock->shouldReceive('databases')
+        ->once()
+        ->with($this->serverId)
+        ->andReturn([
+            (object) ['name' => $this->dbName, 'id' => $dbId],
+        ]);
+
+    // Should delete the database
+    $this->forgeMock->shouldReceive('deleteDatabase')
+        ->once()
+        ->with($this->serverId, $dbId);
+
+    // Mock existing user
+    $this->forgeMock->shouldReceive('databaseUsers')
+        ->once()
+        ->with($this->serverId)
+        ->andReturn([
+            (object) ['name' => $this->dbName, 'id' => $userId],
+        ]);
+
+    // Should delete the database user
+    $this->forgeMock->shouldReceive('deleteDatabaseUser')
+        ->once()
+        ->with($this->serverId, $userId);
+
+    // Should create a new database
+    $this->forgeMock->shouldReceive('createDatabase')
+        ->once()
+        ->with($this->serverId, [
+            'name' => $this->dbName,
+            'user' => $this->dbName,
+            'password' => $this->dbPassword,
+        ]);
+
+    // Create a partial mock to skip actual waiting
+    $actionSpy = Mockery::mock(RecreateDatabase::class)->makePartial();
+    $actionSpy->shouldAllowMockingProtectedMethods();
+    $actionSpy->shouldReceive('waitForDatabaseDeletion')->once()->andReturn(null);
+
+    // Act
+    $result = $actionSpy->handle($this->service, $this->dbName, $this->dbPassword);
+
+    // Assert
+    expect($result)->toBeTrue();
+});
+
+it('creates new database when none exists', function () {
+    // Set the service to use the mocked setting
+    $this->service->setting = $this->settingMock;
+
+    // No existing database
+    $this->forgeMock->shouldReceive('databases')
+        ->once()
+        ->with($this->serverId)
+        ->andReturn([
+            (object) ['name' => 'other_db', 'id' => 55],
+        ]);
+
+    // Check for users (none match)
+    $this->forgeMock->shouldReceive('databaseUsers')
+        ->once()
+        ->with($this->serverId)
+        ->andReturn([
+            (object) ['name' => 'other_user', 'id' => 66],
+        ]);
+
+    // Should create a new database
+    $this->forgeMock->shouldReceive('createDatabase')
+        ->once()
+        ->with($this->serverId, [
+            'name' => $this->dbName,
+            'user' => $this->dbName,
+            'password' => $this->dbPassword,
+        ]);
+
+    // We should not wait for deletion since nothing was deleted
+    $actionSpy = Mockery::mock(RecreateDatabase::class)->makePartial();
+    $actionSpy->shouldAllowMockingProtectedMethods();
+    $actionSpy->shouldNotReceive('waitForDatabaseDeletion');
+
+    // Act
+    $result = $actionSpy->handle($this->service, $this->dbName, $this->dbPassword);
+
+    // Assert
+    expect($result)->toBeTrue();
+});


### PR DESCRIPTION
## Overview
This PR fixes issue #134 by implementing a new RecreateDatabase action class that can optionally force delete existing databases and recreate them with new credentials.

## Changes
- Created a new RecreateDatabase action class that encapsulates database recreation logic
- The action can check if a database exists, optionally delete it based on config, and recreate it
- Updated CreateDatabase pipeline to leverage the new action class
- Added PestPHP tests for the new RecreateDatabase action
- Added a forceDeleteOldDatabase flag to ForgeSetting to control this behavior


## How to Test

### Scenario 1: Existing database with force delete enabled
When you have an existing database on the server with the same name:

1. Set `FORCE_DELETE_OLD_DATABASE=true` in your `.env` file
2. Run Harbor provision to create a site
3. Expected behavior:
   - Harbor deletes the existing database
   - Harbor deletes any existing database user with the same name
   - A new database is created with the same name but new credentials

### Scenario 2: Existing database with force delete disabled
When you have an existing database on the server with the same name:

1. Set `FORCE_DELETE_OLD_DATABASE=false` in your `.env` file (or leave it unset)
2. Run Harbor to create a site
3. Expected behavior:
   - Harbor preserves the existing database
   - Harbor displays a warning about the existing database
   - No new database is created

### Scenario 3: No existing database
When no database exists with the specified name:

1. Run Harbor to create a site (regardless of `FORCE_DELETE_OLD_DATABASE` setting)
2. Expected behavior:
   - A new database is created with the specified name
   - New database credentials are set in the site's `.env` file

Fixes #134