### PR TITLE
Fix explode() null argument error in getFormattedAliases

### DIFF
--- a/app/Services/Forge/ForgeService.php
+++ b/app/Services/Forge/ForgeService.php
@@ -83,9 +83,13 @@ class ForgeService
 
     public function getFormattedAliases(): array
     {
-        $subdomain = $this->setting->subdomainName ?? $this->getFormattedBranchName();
+        if ($this->setting->aliases === null) {
+            return [];
+        }
 
-        return collect(explode(',', $this->setting->aliases) ?? [])
+        $subdomain = $this->setting->subdomainName ?? $this->getFormattedBranchName();
+        
+        return collect(explode(',', $this->setting->aliases))
             ->map(fn($alias) => GenerateDomainName::run(trim($alias), $subdomain))
             ->toArray();
     }


### PR DESCRIPTION
## Description
This PR fixes a PHP type error in `ForgeService::getFormattedAliases()` where `explode()` was being called with a null value.

## Changes
- Added null check for `$this->setting->aliases` before calling `explode()`
- Returns an empty array when aliases is null or has not being set.

ref: https://github.com/mehrancodes/laravel-harbor/pull/136#issuecomment-2975338173