### PR TITLE
Temporary fix for updating environment variables,

### DIFF
--- a/app/Actions/Forge/UpdateForgeEnvironmentVariables.php
+++ b/app/Actions/Forge/UpdateForgeEnvironmentVariables.php
@@ -8,6 +8,7 @@ use App\Actions\MergeEnvironmentVariables;
 use App\Actions\TextToArray;
 use App\Services\Forge\ForgeService;
 use App\Traits\Outputifier;
+use Illuminate\Support\Facades\Http;
 
 class UpdateForgeEnvironmentVariables
 {
@@ -37,11 +38,35 @@ class UpdateForgeEnvironmentVariables
         $source = $service->forge->siteEnvironmentFile($service->server->id, $service->site->id);
         $mergedEnvs = MergeEnvironmentVariables::run($source, $newKeys);
 
-        $service->forge->updateSiteEnvironmentFile(
-            $service->server->id,
-            $service->site->id,
-            $mergedEnvs
-        );
+        // TODO: This is a temporary solution. Direct HTTP call to Forge API should be replaced
+        // with proper SDK support once available. Remove this conditional when SDK supports
+        // organization-based endpoints.
+        $useNewApi = env('USE_NEW_FORGE_API', false) === true || env('USE_NEW_FORGE_API') === 'true';
+        $organization = env('FORGE_ORGANIZATION');
+
+        if ($useNewApi && $organization) {
+            $url = sprintf(
+                'https://forge.laravel.com/api/orgs/%s/servers/%s/sites/%s/environment',
+                $organization,
+                $service->server->id,
+                $service->site->id
+            );
+
+            Http::withHeaders([
+                'Authorization' => sprintf('Bearer %s', $service->setting->token),
+                'Content-Type' => 'application/json',
+            ])->put($url, [
+                'environment' => $mergedEnvs,
+                'cache' => true,
+                'queues' => true,
+            ]);
+        } else {
+            $service->forge->updateSiteEnvironmentFile(
+                $service->server->id,
+                $service->site->id,
+                $mergedEnvs
+            );
+        }
 
         return true;
     }


### PR DESCRIPTION
Got another error today while updating the environment variables:

> The environment file is invalid. Encountered an invalid name at [ no data will be synced yet].

I tested it with the new Forge API, and it works perfectly there. This Fix is temporary using the new Forge API to update env variables if we set env variables **FORGE_ORGANIZATION** and **USE_NEW_FORGE_API**

**USE_NEW_FORGE_API is a temporary var**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Enhanced environment variable update mechanism with conditional configuration path support while maintaining backward compatibility with existing deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->