### PR TITLE
fix: add custom validation message for missing FORGE_ORGANIZATION

### DIFF
--- a/app/Services/Forge/ForgeSetting.php
+++ b/app/Services/Forge/ForgeSetting.php
@@ -297,6 +297,8 @@ class ForgeSetting
             'github_create_deploy_key' => ['required', 'boolean'],
             'queue_workers' => ['nullable', 'string'],
             'daemons' => ['nullable', 'string'],
+        ], [
+            'organization.required' => 'Forge Organization ID is required for Harbor v2. Please add it to your Harbor workflow configuration, or use Harbor v1. See: http://laravel-harbor.com/docs/upgrade-to-v2',
         ])->sometimes('git_provider', 'in:custom', function (Fluent $input) {
             return $input->github_create_deploy_key === true;
         });


### PR DESCRIPTION
## Summary
- Add a custom `organization.required` validation message in `ForgeSetting`
- When `FORGE_ORGANIZATION` is missing, Harbor now points users to the v2 upgrade docs or suggests staying on v1

## Test plan
- [ ] Run Harbor without `FORGE_ORGANIZATION` set and confirm the custom message is shown instead of the generic required-field error
- [ ] Run Harbor with `FORGE_ORGANIZATION` set and confirm provisioning still works as expected