### PR TITLE
fix scheduler job name collisions on Forge

### DIFF
--- a/app/Services/Forge/Data/ForgeJobData.php
+++ b/app/Services/Forge/Data/ForgeJobData.php
@@ -10,6 +10,7 @@ class ForgeJobData
 {
     public function __construct(
         public int|string $id,
+        public string $name,
         public string $command,
         public ?string $user,
     ) {
@@ -22,6 +23,7 @@ class ForgeJobData
 
         return new self(
             id: JsonApiData::id($resource),
+            name: (string) ($attributes['name'] ?? ''),
             command: (string) ($attributes['command'] ?? ''),
             user: $attributes['user'] ?? null,
         );

--- a/app/Services/Forge/Pipeline/EnsureJobScheduled.php
+++ b/app/Services/Forge/Pipeline/EnsureJobScheduled.php
@@ -20,6 +20,7 @@ use Closure;
 class EnsureJobScheduled
 {
     use Outputifier;
+    protected const SCHEDULER_JOB_NAME = 'Harbor scheduler';
 
     public function __invoke(ForgeService $service, Closure $next)
     {
@@ -35,7 +36,7 @@ class EnsureJobScheduled
         $command = $this->buildScheduledJobCommand($service->site->username, $service->site->name);
 
         foreach ($service->jobs() as $job) {
-            if ($job->command === $command) {
+            if ($job->name === self::SCHEDULER_JOB_NAME && $job->command === $command) {
                 $this->information('Scheduler job is already in place.');
 
                 return;
@@ -44,7 +45,7 @@ class EnsureJobScheduled
 
         $this->information('Creating a new scheduler job.');
         $service->createJob([
-            'name' => 'Harbor scheduler',
+            'name' => self::SCHEDULER_JOB_NAME,
             'command' => $command,
             'frequency' => 'minutely',
             'user' => $service->site->username,

--- a/app/Services/Forge/Pipeline/EnsureJobScheduled.php
+++ b/app/Services/Forge/Pipeline/EnsureJobScheduled.php
@@ -20,7 +20,7 @@ use Closure;
 class EnsureJobScheduled
 {
     use Outputifier;
-    protected const SCHEDULER_JOB_NAME = 'Harbor scheduler';
+    protected const SCHEDULER_JOB_PREFIX = 'Harbor scheduler';
 
     public function __invoke(ForgeService $service, Closure $next)
     {
@@ -33,10 +33,11 @@ class EnsureJobScheduled
 
     private function setupJobIfRequired(ForgeService $service): void
     {
+        $jobName = $this->buildScheduledJobName($service->site->name);
         $command = $this->buildScheduledJobCommand($service->site->username, $service->site->name);
 
         foreach ($service->jobs() as $job) {
-            if ($job->name === self::SCHEDULER_JOB_NAME && $job->command === $command) {
+            if ($job->name === $jobName && $job->command === $command) {
                 $this->information('Scheduler job is already in place.');
 
                 return;
@@ -45,11 +46,16 @@ class EnsureJobScheduled
 
         $this->information('Creating a new scheduler job.');
         $service->createJob([
-            'name' => self::SCHEDULER_JOB_NAME,
+            'name' => $jobName,
             'command' => $command,
             'frequency' => 'minutely',
             'user' => $service->site->username,
         ]);
+    }
+
+    protected function buildScheduledJobName(string $siteName): string
+    {
+        return sprintf('%s %s', self::SCHEDULER_JOB_PREFIX, $siteName);
     }
 
     protected function buildScheduledJobCommand(string $username, string $domain): string

--- a/tests/Unit/Services/Forge/Pipeline/EnsureJobScheduledTest.php
+++ b/tests/Unit/Services/Forge/Pipeline/EnsureJobScheduledTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Services\Forge\Api\ForgeClient;
+use App\Services\Forge\Data\ForgeJobData;
+use App\Services\Forge\Data\ForgeSiteData;
+use App\Services\Forge\ForgeService;
+use App\Services\Forge\ForgeSetting;
+use App\Services\Forge\Pipeline\EnsureJobScheduled;
+
+test('it skips scheduler creation when same name and command exist', function () {
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->jobSchedulerRequired = true;
+    $setting->server = '936639';
+    $client = Mockery::mock(ForgeClient::class);
+
+    $service = new ForgeService($setting, $client);
+    $service->site = new ForgeSiteData(
+        id: 1,
+        name: 'new-timefolio-pr-23.timefolio.app',
+        status: null,
+        username: 'forge',
+        repository: null,
+        webDirectory: '/home/forge/new-timefolio-pr-23.timefolio.app/public',
+        rootDirectory: '/home/forge/new-timefolio-pr-23.timefolio.app',
+        directory: '/public',
+        deploymentUrl: null,
+    );
+
+    $expectedName = 'Harbor scheduler new-timefolio-pr-23.timefolio.app';
+    $expectedCommand = 'php /home/forge/new-timefolio-pr-23.timefolio.app/artisan schedule:run';
+
+    $client->shouldReceive('listJobs')
+        ->once()
+        ->with('936639')
+        ->andReturn([
+            new ForgeJobData(
+                id: 7,
+                name: $expectedName,
+                command: $expectedCommand,
+                user: 'forge',
+            ),
+        ]);
+
+    $client->shouldNotReceive('createJob');
+
+    $result = (new EnsureJobScheduled())($service, fn ($passedService) => $passedService);
+
+    expect($result)->toBe($service);
+});
+
+test('it creates scheduler when same name exists with different command', function () {
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->jobSchedulerRequired = true;
+    $setting->server = '936639';
+    $client = Mockery::mock(ForgeClient::class);
+
+    $service = new ForgeService($setting, $client);
+    $service->site = new ForgeSiteData(
+        id: 1,
+        name: 'new-timefolio-pr-23.timefolio.app',
+        status: null,
+        username: 'forge',
+        repository: null,
+        webDirectory: '/home/forge/new-timefolio-pr-23.timefolio.app/public',
+        rootDirectory: '/home/forge/new-timefolio-pr-23.timefolio.app',
+        directory: '/public',
+        deploymentUrl: null,
+    );
+
+    $expectedName = 'Harbor scheduler new-timefolio-pr-23.timefolio.app';
+    $expectedCommand = 'php /home/forge/new-timefolio-pr-23.timefolio.app/artisan schedule:run';
+
+    $client->shouldReceive('listJobs')
+        ->once()
+        ->with('936639')
+        ->andReturn([
+            new ForgeJobData(
+                id: 8,
+                name: $expectedName,
+                command: 'php /home/forge/legacy.timefolio.app/artisan schedule:run',
+                user: 'forge',
+            ),
+        ]);
+
+    $client->shouldReceive('createJob')
+        ->once()
+        ->with('936639', [
+            'name' => $expectedName,
+            'command' => $expectedCommand,
+            'frequency' => 'minutely',
+            'user' => 'forge',
+        ]);
+
+    $result = (new EnsureJobScheduled())($service, fn ($passedService) => $passedService);
+
+    expect($result)->toBe($service);
+});
+
+test('it does nothing when scheduler is disabled', function () {
+    $setting = Mockery::mock(ForgeSetting::class);
+    $setting->jobSchedulerRequired = false;
+    $setting->server = '936639';
+    $client = Mockery::mock(ForgeClient::class);
+
+    $service = new ForgeService($setting, $client);
+    $service->site = new ForgeSiteData(
+        id: 1,
+        name: 'new-timefolio-pr-23.timefolio.app',
+        status: null,
+        username: 'forge',
+        repository: null,
+        webDirectory: '/home/forge/new-timefolio-pr-23.timefolio.app/public',
+        rootDirectory: '/home/forge/new-timefolio-pr-23.timefolio.app',
+        directory: '/public',
+        deploymentUrl: null,
+    );
+
+    $client->shouldNotReceive('listJobs');
+    $client->shouldNotReceive('createJob');
+
+    $result = (new EnsureJobScheduled())($service, fn ($passedService) => $passedService);
+
+    expect($result)->toBe($service);
+});


### PR DESCRIPTION
## Summary
- make scheduled job creation idempotent by requiring a match on both job `name` and `command`
- generate scheduler job names from the Forge site name (`Harbor scheduler <site-name>`) to avoid cross-environment name collisions
- add dedicated tests for `EnsureJobScheduled` covering existing match, conflict path, and disabled scheduler behavior

## Issue
Preview/provision deploys were failing on Forge with a validation error:

- `name: The name has already been taken.`

This happened when Harbor attempted to create a scheduled job with a colliding name on the same Forge server, even across different preview environments.

## Why this fix
- checking only by command was not enough to avoid Forge name-collision failures
- using a site-based scheduler name makes jobs unique per provisioned environment
- requiring `name + command` for idempotency keeps re-runs safe while avoiding false positives

## Test plan
- [x] Run `./vendor/bin/pest`
- [x] Verify new tests in `tests/Unit/Services/Forge/Pipeline/EnsureJobScheduledTest.php` pass
- [ ] Run Harbor deploy workflow against a PR preview env to confirm no Forge "name already taken" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved scheduled job creation to ensure proper naming conventions.
  * Improved job matching logic to prevent duplicate scheduled task creation.

* **Improvements**
  * Scheduled jobs now have consistent, centralized naming for better tracking and identification.

* **Tests**
  * Added comprehensive unit test coverage for job scheduling pipeline workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->